### PR TITLE
Hotfix - Timepicker, spotlight date

### DIFF
--- a/src/components/forms/TimePicker.tsx
+++ b/src/components/forms/TimePicker.tsx
@@ -14,8 +14,8 @@ type TimeOption = { value: string; label: string };
 const timeOptions: TimeOption[] = Array.from({ length: 24 * 2 }, (_, i) => {
   const h = Math.floor(i / 2);
   const m = i % 2 === 0 ? "00" : "30";
-  const raw = `${h.toString().padStart(2, "0")}:${m}`;
-  const display = new Date(`1970-01-01T${raw}:00`).toLocaleTimeString([], {
+  const raw = `${h.toString().padStart(2, "0")}:${m}:00`;
+  const display = new Date(`1970-01-01T${raw}`).toLocaleTimeString([], {
     hour: "2-digit",
     minute: "2-digit",
     hour12: true,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -26,6 +26,6 @@ export type CreateEventDto = {
   recurrence?: string;
 
   isAlwaysOpen?: boolean;
-  spotlight?: boolean;
-  spotlightDate?: string;
+  spotlight?: false; // change once implemented
+  spotlightDate?: null; // change once implemented
 };


### PR DESCRIPTION
Fixed the issue with timespan, included seconds that was missing.
spotlight values they now send a a null instead of empty string.