### PR TITLE
Fix health check redirect in deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Health check
         run: |
           for i in 1 2 3 4 5; do
-            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${{ vars.DEPLOY_URL }}" || true)
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L "${{ vars.DEPLOY_URL }}" || true)
             if [ "$HTTP_STATUS" = "200" ]; then
               echo "Health check passed (HTTP $HTTP_STATUS)"
               exit 0


### PR DESCRIPTION
Follow redirects with curl -L since the frontend returns 307 from root URL.