### PR TITLE
Redesign preview to match Expo accessibility-redesign

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -129,3 +129,10 @@
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
+
+/* RGB shift animation for featured card border in preview */
+@keyframes rgbShift {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}

--- a/src/components/preview/AppPreview.tsx
+++ b/src/components/preview/AppPreview.tsx
@@ -7,12 +7,16 @@ import { ResultsScreen } from "./screens/ResultsScreen";
 import { EventDetailScreen } from "./screens/EventDetailScreen";
 
 type Screen =
-  | { type: "home"; tagCodes: number[] }
-  | { type: "results"; categoryCode: number; tagCodes: number[] }
+  | { type: "home"; tagCodes: number[]; selectedCategories: number[] }
+  | { type: "results"; categoryCode: number; tagCodes: number[]; showMap: boolean }
   | { type: "detail"; eventId: string; fromCategory: number; tagCodes: number[] };
 
 export function AppPreview() {
-  const [screen, setScreen] = useState<Screen>({ type: "home", tagCodes: [] });
+  const [screen, setScreen] = useState<Screen>({
+    type: "home",
+    tagCodes: [],
+    selectedCategories: [],
+  });
 
   const handleTagsChange = (newTagCodes: number[]) => {
     setScreen((prev) => ({ ...prev, tagCodes: newTagCodes }));
@@ -23,12 +27,32 @@ export function AppPreview() {
       {screen.type === "home" && (
         <HomeScreen
           tagCodes={screen.tagCodes}
+          selectedCategories={screen.selectedCategories}
           onTagsChange={handleTagsChange}
-          onSelectCategory={(code) =>
-            setScreen({ type: "results", categoryCode: code, tagCodes: screen.tagCodes })
+          onToggleCategory={(code) => {
+            setScreen((prev) => {
+              if (prev.type !== "home") return prev;
+              const cats = prev.selectedCategories.includes(code)
+                ? prev.selectedCategories.filter((c) => c !== code)
+                : [...prev.selectedCategories, code];
+              return { ...prev, selectedCategories: cats };
+            });
+          }}
+          onGoDo={(categoryCodes) =>
+            setScreen({
+              type: "results",
+              categoryCode: categoryCodes[0] ?? 1,
+              tagCodes: screen.tagCodes,
+              showMap: false,
+            })
           }
           onSelectEvent={(eventId, categoryCode) =>
-            setScreen({ type: "detail", eventId, fromCategory: categoryCode, tagCodes: screen.tagCodes })
+            setScreen({
+              type: "detail",
+              eventId,
+              fromCategory: categoryCode,
+              tagCodes: screen.tagCodes,
+            })
           }
         />
       )}
@@ -37,8 +61,16 @@ export function AppPreview() {
         <ResultsScreen
           categoryCode={screen.categoryCode}
           tagCodes={screen.tagCodes}
+          showMap={screen.showMap}
+          onToggleMap={() =>
+            setScreen((prev) =>
+              prev.type === "results" ? { ...prev, showMap: !prev.showMap } : prev,
+            )
+          }
           onTagsChange={handleTagsChange}
-          onBack={() => setScreen({ type: "home", tagCodes: screen.tagCodes })}
+          onBack={() =>
+            setScreen({ type: "home", tagCodes: screen.tagCodes, selectedCategories: [] })
+          }
           onSelectEvent={(eventId) =>
             setScreen({
               type: "detail",
@@ -58,6 +90,7 @@ export function AppPreview() {
               type: "results",
               categoryCode: screen.fromCategory,
               tagCodes: screen.tagCodes,
+              showMap: false,
             })
           }
         />

--- a/src/components/preview/PhoneFrame.tsx
+++ b/src/components/preview/PhoneFrame.tsx
@@ -24,10 +24,13 @@ export function PhoneFrame({ children }: PhoneFrameProps) {
         {/* Screen area */}
         <div
           className="relative w-full h-full rounded-[38px] overflow-hidden flex flex-col"
-          style={{ backgroundColor: BRAND.yellow }}
+          style={{ backgroundColor: BRAND.background }}
         >
           {/* Status bar */}
-          <div className="flex-shrink-0 flex items-center justify-between px-6 pt-8 pb-2 text-[11px] font-semibold text-gray-800">
+          <div
+            className="flex-shrink-0 flex items-center justify-between px-6 pt-8 pb-1 text-[11px] font-semibold"
+            style={{ color: BRAND.textBody }}
+          >
             <span>9:41</span>
             <div className="flex items-center gap-1">
               <svg width="16" height="11" viewBox="0 0 16 11" fill="currentColor">
@@ -51,7 +54,7 @@ export function PhoneFrame({ children }: PhoneFrameProps) {
 
           {/* Home indicator */}
           <div className="flex-shrink-0 flex justify-center pb-2 pt-1">
-            <div className="w-[120px] h-[4px] rounded-full" style={{ backgroundColor: "rgba(0,0,0,0.25)" }} />
+            <div className="w-[120px] h-[4px] rounded-full" style={{ backgroundColor: "rgba(0,0,0,0.15)" }} />
           </div>
         </div>
       </div>

--- a/src/components/preview/constants.ts
+++ b/src/components/preview/constants.ts
@@ -1,16 +1,23 @@
-// Mobile app design tokens — matches the Go.Do Expo app visual identity
+// Mobile app design tokens — matches the Go.Do Expo app accessibility-redesign
 
+// ── Brand palette ─────────────────────────────────────────────────
 export const BRAND = {
   yellow: "#F3C10E",
-  yellowLight: "#FFF8DC",
+  yellowLight: "#FFF9D6",
+  yellowDark: "#D4A80C",
+  onPrimary: "#2A2000",
   background: "#FAF8F3",
-  surface: "#FFFFFF",
-  textPrimary: "#1A1A1A",
-  textSecondary: "#6B7280",
-  border: "#E5E7EB",
+  surface: "#FFFEFA",
+  textPrimary: "#1C1C1E",
+  textBody: "#3C3C43",
+  textSecondary: "#8E8E93",
+  border: "#E8E5DD",
+  neutral100: "#F5F2EB",
+  neutral200: "#E8E5DD",
+  neutral300: "#D1CEC6",
 } as const;
 
-// Category colors — strong, used for icons and accents
+// ── Category dark colors (AAA contrast on white) ─────────────────
 export const CATEGORY_COLORS: Record<number, string> = {
   1: "#991B1B", // Events — red
   2: "#581C87", // Sports — purple
@@ -21,29 +28,29 @@ export const CATEGORY_COLORS: Record<number, string> = {
   7: "#9D174D", // Health — pink
 };
 
-// Category tints — pastel backgrounds for tiles
+// ── Category tints (soft pastels for tile backgrounds) ────────────
 export const CATEGORY_TINTS: Record<number, string> = {
-  1: "#FEE2E2", // red-100
-  2: "#F3E8FF", // purple-100
-  3: "#DBEAFE", // blue-100 (navy tint)
-  4: "#DBEAFE", // blue-100
-  5: "#F3F4F6", // gray-100
-  6: "#FFEDD5", // orange-100
-  7: "#FCE7F3", // pink-100
+  1: "#FEF2F2",
+  2: "#F5F3FF",
+  3: "#EFF6FF",
+  4: "#F0F9FF",
+  5: "#F5F5F4",
+  6: "#FFF7ED",
+  7: "#FDF2F8",
 };
 
-// Gradient pairs for hero sections in detail screen
+// ── Gradient pairs for hero sections ──────────────────────────────
 export const CATEGORY_GRADIENTS: Record<number, [string, string]> = {
-  1: ["#991B1B", "#DC2626"],
-  2: ["#581C87", "#7C3AED"],
-  3: ["#1E3A5F", "#3B82F6"],
-  4: ["#1E3A8A", "#60A5FA"],
-  5: ["#374151", "#6B7280"],
-  6: ["#7C2D12", "#EA580C"],
-  7: ["#9D174D", "#EC4899"],
+  1: ["#FCA5A5", "#F87171"],
+  2: ["#C4B5FD", "#A78BFA"],
+  3: ["#93C5FD", "#60A5FA"],
+  4: ["#7DD3FC", "#38BDF8"],
+  5: ["#A8A29E", "#78716C"],
+  6: ["#FDBA74", "#FB923C"],
+  7: ["#F9A8D4", "#F472B6"],
 };
 
-// Short labels for category tiles (mobile-friendly, Swedish)
+// ── Short labels (Swedish) ────────────────────────────────────────
 export const CATEGORY_SHORT_LABELS: Record<number, string> = {
   1: "Evenemang",
   2: "Idrott",
@@ -52,4 +59,23 @@ export const CATEGORY_SHORT_LABELS: Record<number, string> = {
   5: "Upplevelser",
   6: "Utforska",
   7: "Hälsa",
+};
+
+// ── Category icons for the map pins ───────────────────────────────
+export const CATEGORY_EMOJIS: Record<number, string> = {
+  1: "🎉",
+  2: "⚽",
+  3: "🎭",
+  4: "🏛️",
+  5: "🏔️",
+  6: "📚",
+  7: "🧘",
+};
+
+// ── GPS coordinates for mock events (Helsingborg area) ────────────
+export const HELSINGBORG_CENTER = { lat: 56.0465, lng: 12.6945 };
+export const MOCK_LOCATIONS: Record<string, { lat: number; lng: number }> = {
+  Helsingborg: { lat: 56.0465, lng: 12.6945 },
+  "Malmö": { lat: 55.6050, lng: 13.0038 },
+  Lund: { lat: 55.7047, lng: 13.1910 },
 };

--- a/src/components/preview/screens/EventDetailScreen.tsx
+++ b/src/components/preview/screens/EventDetailScreen.tsx
@@ -5,14 +5,18 @@ import {
   CATEGORY_COLORS,
   CATEGORY_GRADIENTS,
   CATEGORY_TINTS,
+  CATEGORY_SHORT_LABELS,
 } from "../constants";
 import { MOCK_EVENTS } from "../mockEvents";
 import {
   ArrowLeft,
+  Share2,
   MapPin,
   CalendarDays,
   Clock,
   ExternalLink,
+  User,
+  Navigation,
 } from "lucide-react";
 import { format } from "date-fns";
 import { sv } from "date-fns/locale";
@@ -27,12 +31,20 @@ export function EventDetailScreen({ eventId, onBack }: EventDetailScreenProps) {
 
   if (!event) {
     return (
-      <div className="flex flex-col items-center justify-center py-20 gap-2">
-        <p className="text-[13px]" style={{ color: BRAND.textSecondary }}>Evenemanget hittades inte</p>
+      <div className="flex flex-col items-center justify-center py-20 gap-3">
+        <div
+          className="w-[48px] h-[48px] rounded-full flex items-center justify-center"
+          style={{ backgroundColor: BRAND.neutral100 }}
+        >
+          <MapPin size={20} style={{ color: BRAND.textSecondary }} />
+        </div>
+        <p className="text-[13px]" style={{ color: BRAND.textSecondary }}>
+          Evenemanget hittades inte
+        </p>
         <button
           onClick={onBack}
-          className="text-[13px] font-medium"
-          style={{ color: BRAND.yellow }}
+          className="text-[13px] font-semibold px-4 py-2 rounded-full"
+          style={{ backgroundColor: BRAND.yellow, color: BRAND.onPrimary }}
         >
           Gå tillbaka
         </button>
@@ -52,167 +64,281 @@ export function EventDetailScreen({ eventId, onBack }: EventDetailScreenProps) {
       : null;
 
   const timeLabel = event.startDate
-    ? format(new Date(event.startDate), "h:mm a")
+    ? format(new Date(event.startDate), "HH:mm")
     : event.scheduleStartTime
       ? event.scheduleStartTime.substring(0, 5)
       : null;
 
-  const address = [event.streetName, event.houseNumber, event.city]
+  const fullAddress = [event.streetName, event.houseNumber, event.city]
     .filter(Boolean)
     .join(", ");
 
+  const hasCta = event.bookingUrl || event.eventUrl || fullAddress;
+  const ctaLabel = event.bookingUrl
+    ? "Boka biljetter"
+    : event.eventUrl
+      ? "Besök webbplats"
+      : fullAddress
+        ? "Vägbeskrivning"
+        : "";
+
   return (
-    <div>
-      {/* Hero gradient */}
-      <div
-        className="px-4 pt-1 pb-4"
-        style={{
-          background: `linear-gradient(135deg, ${gradient[0]}, ${gradient[1]})`,
-        }}
-      >
-        <button
-          onClick={onBack}
-          className="flex items-center gap-1 text-[13px] font-medium text-white/80 mb-3 active:opacity-70"
-        >
-          <ArrowLeft size={16} />
-          Tillbaka
-        </button>
+    <div className="relative flex flex-col" style={{ backgroundColor: BRAND.yellow, minHeight: "100%" }}>
+      {/* Hero section — 300dp with category gradient */}
+      <div className="relative" style={{ height: "260px" }}>
+        {/* Category gradient background */}
+        <div
+          className="absolute inset-0"
+          style={{
+            background: `linear-gradient(135deg, ${gradient[0]}, ${gradient[1]})`,
+          }}
+        />
+        {/* Dark scrim overlay — bottom vignette */}
+        <div
+          className="absolute inset-0"
+          style={{
+            background: "linear-gradient(to bottom, transparent 30%, rgba(0,0,0,0.55))",
+          }}
+        />
 
-        <h1 className="text-[18px] font-bold text-white leading-snug break-words">
-          {event.title}
-        </h1>
+        {/* Floating back & share buttons */}
+        <div className="absolute top-0 left-0 right-0 flex items-center justify-between px-5 pt-2 z-10">
+          <button
+            onClick={onBack}
+            className="w-[40px] h-[40px] rounded-full flex items-center justify-center active:scale-95 transition-transform"
+            style={{
+              backgroundColor: "rgba(255,255,255,0.9)",
+              boxShadow: "0 1px 3px rgba(0,0,0,0.04)",
+            }}
+          >
+            <ArrowLeft size={22} style={{ color: BRAND.textPrimary }} />
+          </button>
+          <button
+            className="w-[40px] h-[40px] rounded-full flex items-center justify-center active:scale-95 transition-transform"
+            style={{
+              backgroundColor: "rgba(255,255,255,0.9)",
+              boxShadow: "0 1px 3px rgba(0,0,0,0.04)",
+            }}
+          >
+            <Share2 size={20} style={{ color: BRAND.textPrimary }} />
+          </button>
+        </div>
 
-        {event.organiser && (
-          <p className="text-[11px] text-white/70 mt-1">
-            av {event.organiser}
-          </p>
-        )}
-      </div>
-
-      {/* Content */}
-      <div
-        className="mx-2 -mt-1 px-3 pt-3 pb-4 rounded-2xl"
-        style={{ backgroundColor: BRAND.surface, border: `1px solid ${BRAND.border}` }}
-      >
-        {/* Tag pills */}
-        {(event.categories?.length > 0 ||
-          event.subcategories?.length > 0 ||
-          event.tags?.length > 0) && (
-          <div className="flex flex-wrap gap-1.5 mb-4">
-            {event.categories?.map((cat) => (
-              <span
-                key={cat.code}
-                className="text-[10px] font-bold uppercase tracking-wide px-2.5 py-1 rounded-full"
-                style={{ backgroundColor: tint, color }}
-              >
-                {cat.name}
-              </span>
-            ))}
-            {event.subcategories?.map((sub) => (
-              <span
-                key={sub.code}
-                className="text-[10px] font-medium px-2.5 py-1 rounded-full border"
-                style={{ borderColor: BRAND.border, color: BRAND.textSecondary }}
-              >
-                {sub.name}
-              </span>
-            ))}
-            {event.tags?.map((tag) => (
+        {/* Hero tag pills — positioned at bottom-left of hero */}
+        {event.tags && event.tags.length > 0 && (
+          <div className="absolute bottom-8 left-5 flex flex-wrap gap-1.5 z-10">
+            {event.tags.map((tag) => (
               <span
                 key={tag.code}
-                className="text-[10px] font-medium px-2.5 py-1 rounded-full"
-                style={{ backgroundColor: "#FEF9C3", color: "#92400E" }}
+                className="px-2.5 py-1 rounded-full text-[12px] font-semibold"
+                style={{
+                  backgroundColor: "rgba(255,255,255,0.85)",
+                  color: BRAND.textPrimary,
+                }}
               >
                 {tag.name}
               </span>
             ))}
           </div>
         )}
+      </div>
 
-        {/* Info rows */}
-        <div className="flex flex-col gap-2.5 mb-4">
+      {/* Content sheet — overlaps hero by -20px, rounded yellow corners */}
+      <div
+        className="relative flex-1"
+        style={{
+          backgroundColor: BRAND.surface,
+          borderTopLeftRadius: "24px",
+          borderTopRightRadius: "24px",
+          marginTop: "-20px",
+          paddingBottom: hasCta ? "80px" : "20px",
+        }}
+      >
+        <div className="px-5 pt-6">
+          {/* Title */}
+          <h1
+            className="text-[24px] font-bold leading-snug break-words mb-1"
+            style={{ color: BRAND.textPrimary }}
+          >
+            {event.title}
+          </h1>
+
+          {/* Category meta */}
+          <p className="text-[13px] mb-1" style={{ color: BRAND.textSecondary }}>
+            {CATEGORY_SHORT_LABELS[categoryCode]}
+            {event.subcategories?.[0] && ` · ${event.subcategories[0].name}`}
+          </p>
+
+          {/* Date */}
           {dateLabel && (
-            <div className="flex items-start gap-2.5">
-              <CalendarDays size={15} className="mt-0.5 flex-shrink-0" style={{ color }} />
-              <div className="min-w-0">
-                <p className="text-[12px] font-medium break-words" style={{ color: BRAND.textPrimary }}>
-                  {dateLabel}
+            <p
+              className="text-[16px] font-semibold mb-6"
+              style={{ color: BRAND.textPrimary }}
+            >
+              {dateLabel}
+              {timeLabel && (
+                <span style={{ color: BRAND.textSecondary, fontWeight: 400 }}>
+                  {" "}
+                  kl. {timeLabel}
+                </span>
+              )}
+            </p>
+          )}
+
+          {/* Category & subcategory pills */}
+          {(event.categories?.length > 0 || event.subcategories?.length > 0) && (
+            <div className="flex flex-wrap gap-1.5 mb-6">
+              {event.categories?.map((cat) => (
+                <span
+                  key={cat.code}
+                  className="text-[10px] font-bold uppercase tracking-wide px-2.5 py-1 rounded-full"
+                  style={{ backgroundColor: tint, color }}
+                >
+                  {cat.name}
+                </span>
+              ))}
+              {event.subcategories?.map((sub) => (
+                <span
+                  key={sub.code}
+                  className="text-[10px] font-medium px-2.5 py-1 rounded-full border"
+                  style={{ borderColor: BRAND.border, color: BRAND.textSecondary }}
+                >
+                  {sub.name}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* About section */}
+          {event.description && (
+            <div className="mb-6">
+              <h2
+                className="text-[20px] font-semibold mb-2"
+                style={{ color: BRAND.textPrimary }}
+              >
+                Om evenemanget
+              </h2>
+              <p
+                className="text-[15px] leading-relaxed break-words"
+                style={{ color: BRAND.textBody }}
+              >
+                {event.description}
+              </p>
+            </div>
+          )}
+
+          {/* Organiser section */}
+          {event.organiser && (
+            <div className="mb-6">
+              <p
+                className="text-[11px] font-bold uppercase tracking-wider mb-1"
+                style={{ color: BRAND.textSecondary }}
+              >
+                Arrangör
+              </p>
+              <div className="flex items-center gap-2">
+                <div
+                  className="w-[28px] h-[28px] rounded-full flex items-center justify-center"
+                  style={{ backgroundColor: BRAND.neutral100 }}
+                >
+                  <User size={14} style={{ color: BRAND.textSecondary }} />
+                </div>
+                <p className="text-[15px]" style={{ color: BRAND.textBody }}>
+                  {event.organiser}
                 </p>
-                {timeLabel && (
-                  <p className="text-[11px]" style={{ color: BRAND.textSecondary }}>
-                    {timeLabel}
-                  </p>
-                )}
               </div>
             </div>
           )}
 
-          {address && (
-            <div className="flex items-start gap-2.5">
-              <MapPin size={15} className="mt-0.5 flex-shrink-0" style={{ color }} />
-              <p className="text-[12px] break-words min-w-0" style={{ color: BRAND.textPrimary }}>
-                {address}
+          {/* Location section */}
+          {fullAddress && (
+            <div className="mb-6">
+              <p
+                className="text-[11px] font-bold uppercase tracking-wider mb-1"
+                style={{ color: BRAND.textSecondary }}
+              >
+                Plats
               </p>
+              <div className="flex items-center gap-2">
+                <div
+                  className="w-[28px] h-[28px] rounded-full flex items-center justify-center"
+                  style={{ backgroundColor: BRAND.neutral100 }}
+                >
+                  <MapPin size={14} style={{ color: BRAND.textSecondary }} />
+                </div>
+                <p className="text-[15px] break-words" style={{ color: BRAND.textBody }}>
+                  {fullAddress}
+                </p>
+              </div>
             </div>
           )}
 
+          {/* Schedule section */}
           {event.hasSchedule && event.scheduleStartTime && (
-            <div className="flex items-start gap-2.5">
-              <Clock size={15} className="mt-0.5 flex-shrink-0" style={{ color }} />
-              <p className="text-[12px] break-words min-w-0" style={{ color: BRAND.textPrimary }}>
-                {event.scheduleStartTime.substring(0, 5)}
-                {event.scheduleEndTime && ` – ${event.scheduleEndTime.substring(0, 5)}`}
-                {event.recurrence && ` (${event.recurrence})`}
+            <div className="mb-6">
+              <p
+                className="text-[11px] font-bold uppercase tracking-wider mb-1"
+                style={{ color: BRAND.textSecondary }}
+              >
+                Tider
               </p>
+              <div className="flex items-center gap-2">
+                <div
+                  className="w-[28px] h-[28px] rounded-full flex items-center justify-center"
+                  style={{ backgroundColor: BRAND.neutral100 }}
+                >
+                  <Clock size={14} style={{ color: BRAND.textSecondary }} />
+                </div>
+                <p className="text-[15px]" style={{ color: BRAND.textBody }}>
+                  {event.scheduleStartTime.substring(0, 5)}
+                  {event.scheduleEndTime && ` – ${event.scheduleEndTime.substring(0, 5)}`}
+                  {event.recurrence && (
+                    <span style={{ color: BRAND.textSecondary }}> ({event.recurrence})</span>
+                  )}
+                </p>
+              </div>
             </div>
           )}
-        </div>
 
-        {/* Description */}
-        {event.description && (
-          <div className="mb-4">
-            <h2
-              className="text-[13px] font-bold mb-1"
-              style={{ color: BRAND.textPrimary }}
-            >
-              Om evenemanget
-            </h2>
-            <p
-              className="text-[12px] leading-relaxed break-words"
-              style={{ color: BRAND.textSecondary }}
-            >
-              {event.description}
+          {/* Source attribution */}
+          <div
+            className="pt-3 mt-2"
+            style={{ borderTop: `1px solid ${BRAND.neutral200}` }}
+          >
+            <p className="text-[13px]" style={{ color: BRAND.textSecondary }}>
+              Källa:{" "}
+              {event.sourceProvider === "helsingborg"
+                ? "Helsingborg Events API"
+                : "Go.Do"}
             </p>
           </div>
-        )}
-
-        {/* CTA buttons */}
-        <div className="flex flex-col gap-2">
-          {event.eventUrl && (
-            <a
-              href={event.eventUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-center gap-2 w-full py-2.5 rounded-xl text-[13px] font-semibold text-white transition-opacity active:opacity-80"
-              style={{ backgroundColor: color }}
-            >
-              <ExternalLink size={14} />
-              Besök webbplats
-            </a>
-          )}
-          {event.bookingUrl && (
-            <a
-              href={event.bookingUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-center gap-2 w-full py-2.5 rounded-xl text-[13px] font-semibold border transition-opacity active:opacity-80"
-              style={{ borderColor: color, color }}
-            >
-              Boka nu
-            </a>
-          )}
         </div>
       </div>
+
+      {/* Sticky CTA bar */}
+      {hasCta && (
+        <div
+          className="absolute bottom-0 left-0 right-0 px-5 py-3 pb-5 z-20"
+          style={{
+            backgroundColor: BRAND.surface,
+            boxShadow: "0 -4px 16px rgba(0,0,0,0.08)",
+          }}
+        >
+          <button
+            className="w-full flex items-center justify-center gap-2 py-3.5 rounded-[26px] text-[16px] font-semibold transition-all active:scale-[0.98] active:opacity-85"
+            style={{
+              backgroundColor: BRAND.yellow,
+              color: BRAND.onPrimary,
+              minHeight: "48px",
+            }}
+          >
+            {event.bookingUrl && <ExternalLink size={16} />}
+            {!event.bookingUrl && event.eventUrl && <ExternalLink size={16} />}
+            {!event.bookingUrl && !event.eventUrl && fullAddress && <Navigation size={16} />}
+            {ctaLabel}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/preview/screens/HomeScreen.tsx
+++ b/src/components/preview/screens/HomeScreen.tsx
@@ -8,68 +8,147 @@ import {
   CATEGORY_COLORS,
   CATEGORY_TINTS,
   CATEGORY_SHORT_LABELS,
+  CATEGORY_GRADIENTS,
 } from "../constants";
 import { filterMockEvents } from "../mockEvents";
-import { MapPin, CalendarDays } from "lucide-react";
+import {
+  MapPin,
+  CalendarDays,
+  Bell,
+  Search,
+  Check,
+  ChevronDown,
+} from "lucide-react";
 import { format } from "date-fns";
 import { sv } from "date-fns/locale";
 
 interface HomeScreenProps {
   tagCodes: number[];
+  selectedCategories: number[];
   onTagsChange: (tagCodes: number[]) => void;
-  onSelectCategory: (code: number) => void;
+  onToggleCategory: (code: number) => void;
+  onGoDo: (categoryCodes: number[]) => void;
   onSelectEvent: (eventId: string, categoryCode: number) => void;
 }
 
-export function HomeScreen({ tagCodes, onTagsChange, onSelectCategory, onSelectEvent }: HomeScreenProps) {
+export function HomeScreen({
+  tagCodes,
+  selectedCategories,
+  onTagsChange,
+  onToggleCategory,
+  onGoDo,
+  onSelectEvent,
+}: HomeScreenProps) {
   const { items: events, totalCount } = useMemo(
-    () => filterMockEvents({
-      tagCodes: tagCodes.length > 0 ? tagCodes : undefined,
-      pageSize: 8,
-    }),
-    [tagCodes],
+    () =>
+      filterMockEvents({
+        categoryCodes: selectedCategories.length > 0 ? selectedCategories : undefined,
+        tagCodes: tagCodes.length > 0 ? tagCodes : undefined,
+        pageSize: 6,
+      }),
+    [tagCodes, selectedCategories],
   );
 
   const toggleTag = (code: number) => {
     onTagsChange(
-      tagCodes.includes(code)
-        ? tagCodes.filter((c) => c !== code)
-        : [...tagCodes, code]
+      tagCodes.includes(code) ? tagCodes.filter((c) => c !== code) : [...tagCodes, code],
     );
   };
 
   return (
-    <div className="px-4 pb-4">
-      {/* Header */}
-      <div className="pt-2 pb-3">
-        <h1 className="text-[18px] font-bold text-gray-900 leading-tight">
-          Hej!
+    <div className="pb-4">
+      {/* Location header */}
+      <div className="flex items-center justify-between px-5 pt-1 pb-2">
+        <button
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium"
+          style={{ backgroundColor: BRAND.neutral100, color: BRAND.textBody }}
+        >
+          <MapPin size={13} />
+          Helsingborg
+          <ChevronDown size={12} />
+        </button>
+        <button
+          className="w-[36px] h-[36px] flex items-center justify-center rounded-full"
+          style={{ backgroundColor: BRAND.neutral100 }}
+        >
+          <Bell size={16} style={{ color: BRAND.textBody }} />
+        </button>
+      </div>
+
+      {/* Greeting */}
+      <div className="px-5 pb-3">
+        <h1
+          className="text-[22px] font-bold leading-tight tracking-wide"
+          style={{ color: BRAND.textPrimary, letterSpacing: "0.25px" }}
+        >
+          Hej! Vad letar du efter idag?
         </h1>
-        <p className="text-[13px] text-gray-500 mt-0.5">
-          Vad letar du efter idag?
-        </p>
+      </div>
+
+      {/* Search bar */}
+      <div className="px-5 pb-3">
+        <div
+          className="flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl"
+          style={{ backgroundColor: BRAND.neutral100 }}
+        >
+          <Search size={16} style={{ color: BRAND.textSecondary }} />
+          <span className="text-[13px]" style={{ color: BRAND.textSecondary }}>
+            Sök evenemang...
+          </span>
+        </div>
+      </div>
+
+      {/* Date pill */}
+      <div className="px-5 pb-3">
+        <button
+          className="flex items-center gap-2 px-4 py-2 rounded-full text-[12px] font-semibold border-2"
+          style={{
+            borderColor: BRAND.yellow,
+            backgroundColor: BRAND.yellowLight,
+            color: BRAND.onPrimary,
+          }}
+        >
+          <CalendarDays size={14} />
+          Välj datum
+        </button>
       </div>
 
       {/* Category tiles — horizontal scroll */}
-      <div className="mb-4">
-        <div className="flex gap-2 overflow-x-auto pb-2 -mx-4 px-4 scrollbar-hide">
+      <div className="mb-3">
+        <div className="flex gap-2.5 overflow-x-auto pb-2 px-5 scrollbar-hide">
           {categoryOptions.map((cat) => {
             const Icon = cat.icon;
-            const color = CATEGORY_COLORS[cat.code];
-            const tint = CATEGORY_TINTS[cat.code];
+            const code = cat.code;
+            const isSelected = selectedCategories.includes(code);
+            const color = CATEGORY_COLORS[code];
+            const tint = CATEGORY_TINTS[code];
             return (
               <button
-                key={cat.code}
-                onClick={() => onSelectCategory(cat.code)}
-                className="flex-shrink-0 flex flex-col items-center justify-center rounded-2xl p-2.5 w-[76px] h-[76px] transition-transform active:scale-95"
-                style={{ backgroundColor: tint, border: `1px solid ${color}20` }}
+                key={code}
+                onClick={() => onToggleCategory(code)}
+                className="relative flex-shrink-0 flex flex-col items-center justify-center rounded-2xl w-[80px] h-[90px] transition-all active:scale-95"
+                style={{
+                  backgroundColor: isSelected ? color : tint,
+                  border: isSelected ? `2px solid ${BRAND.yellow}` : `1px solid ${color}15`,
+                  boxShadow: isSelected
+                    ? `0 2px 8px ${color}40`
+                    : "0 1px 3px rgba(0,0,0,0.04)",
+                }}
               >
-                <Icon size={20} color={color} strokeWidth={2} />
+                {isSelected && (
+                  <div
+                    className="absolute top-1.5 right-1.5 w-[16px] h-[16px] rounded-full flex items-center justify-center"
+                    style={{ backgroundColor: BRAND.yellow }}
+                  >
+                    <Check size={10} strokeWidth={3} style={{ color: BRAND.onPrimary }} />
+                  </div>
+                )}
+                <Icon size={22} color={isSelected ? "#fff" : color} strokeWidth={2} />
                 <span
-                  className="text-[9px] font-semibold mt-1 leading-tight text-center"
-                  style={{ color }}
+                  className="text-[10px] font-semibold mt-1.5 leading-tight text-center"
+                  style={{ color: isSelected ? "#fff" : color }}
                 >
-                  {CATEGORY_SHORT_LABELS[cat.code]}
+                  {CATEGORY_SHORT_LABELS[code]}
                 </span>
               </button>
             );
@@ -78,18 +157,17 @@ export function HomeScreen({ tagCodes, onTagsChange, onSelectCategory, onSelectE
       </div>
 
       {/* Tag filter chips */}
-      <div className="flex gap-1.5 flex-wrap mb-3">
+      <div className="flex gap-1.5 flex-wrap px-5 mb-3">
         {filterOptions.map((tag) => {
           const active = tagCodes.includes(tag.code);
           return (
             <button
               key={tag.code}
               onClick={() => toggleTag(tag.code)}
-              className="flex-shrink-0 px-2.5 py-1 rounded-full text-[10px] font-semibold transition-colors"
+              className="flex-shrink-0 px-3 py-1.5 rounded-full text-[11px] font-medium transition-colors"
               style={{
-                backgroundColor: active ? BRAND.textPrimary : BRAND.surface,
-                color: active ? "#FFFFFF" : BRAND.textSecondary,
-                border: `1px solid ${active ? BRAND.textPrimary : BRAND.border}`,
+                backgroundColor: active ? BRAND.yellow : BRAND.neutral100,
+                color: active ? BRAND.onPrimary : BRAND.textSecondary,
               }}
             >
               {tag.label}
@@ -98,31 +176,54 @@ export function HomeScreen({ tagCodes, onTagsChange, onSelectCategory, onSelectE
         })}
       </div>
 
-      {/* Upcoming section header */}
-      <div className="flex items-center justify-between mb-2.5">
-        <h2
-          className="text-[14px] font-bold"
-          style={{ color: BRAND.textPrimary }}
+      {/* Go.Do! button */}
+      <div className="px-5 mb-4">
+        <button
+          onClick={() => onGoDo(selectedCategories.length > 0 ? selectedCategories : [1])}
+          className="w-full py-3.5 rounded-[26px] text-[16px] font-bold tracking-wide transition-all active:scale-[0.97]"
+          style={{
+            backgroundColor: BRAND.yellow,
+            color: BRAND.onPrimary,
+            boxShadow: "0 4px 12px rgba(243, 193, 14, 0.4)",
+            letterSpacing: "0.5px",
+          }}
         >
-          Kommande evenemang
-        </h2>
-        <span className="text-[11px] font-medium" style={{ color: BRAND.textSecondary }}>
-          {totalCount} totalt
-        </span>
+          Go.Do!
+        </button>
       </div>
 
-      {/* Event cards */}
-      <div className="flex flex-col gap-2.5">
-        {events.map((event) => (
-          <EventCard
+      {/* Upcoming section */}
+      <div className="px-5 mb-2.5">
+        <div className="flex items-center justify-between">
+          <h2
+            className="text-[16px] font-bold"
+            style={{ color: BRAND.textPrimary, letterSpacing: "0.25px" }}
+          >
+            Kommande evenemang
+          </h2>
+          <span className="text-[11px] font-medium" style={{ color: BRAND.textSecondary }}>
+            {totalCount} totalt
+          </span>
+        </div>
+      </div>
+
+      {/* Horizontal event cards */}
+      <div className="flex gap-3 overflow-x-auto px-5 pb-3 scrollbar-hide">
+        {events.slice(0, 5).map((event) => (
+          <UpcomingCard
             key={event.id}
             event={event}
-            onClick={() =>
-              onSelectEvent(event.id, event.categories?.[0]?.code ?? 1)
-            }
+            onClick={() => onSelectEvent(event.id, event.categories?.[0]?.code ?? 1)}
           />
         ))}
       </div>
+
+      {/* Featured carousel placeholder */}
+      {events.length > 0 && (
+        <div className="px-5 mb-2">
+          <FeaturedCard event={events[0]} onClick={() => onSelectEvent(events[0].id, events[0].categories?.[0]?.code ?? 1)} />
+        </div>
+      )}
 
       {events.length === 0 && (
         <p className="text-center text-[12px] py-6" style={{ color: BRAND.textSecondary }}>
@@ -133,58 +234,97 @@ export function HomeScreen({ tagCodes, onTagsChange, onSelectCategory, onSelectE
   );
 }
 
-function EventCard({
-  event,
-  onClick,
-}: {
-  event: EventDto;
-  onClick: () => void;
-}) {
-  const categoryCode = event.categories?.[0]?.code ?? 1;
-  const color = CATEGORY_COLORS[categoryCode] ?? CATEGORY_COLORS[1];
-  const tint = CATEGORY_TINTS[categoryCode] ?? CATEGORY_TINTS[1];
-
+function UpcomingCard({ event, onClick }: { event: EventDto; onClick: () => void }) {
+  const catCode = event.categories?.[0]?.code ?? 1;
+  const gradient = CATEGORY_GRADIENTS[catCode] ?? CATEGORY_GRADIENTS[1];
+  const isFree = event.tags?.some((t) => t.code === 1001);
   const dateLabel = event.startDate
-    ? format(new Date(event.startDate), "d MMM yyyy", { locale: sv })
-    : event.isAlwaysOpen
-      ? "Alltid öppet"
-      : "Datum saknas";
+    ? format(new Date(event.startDate), "d MMM", { locale: sv })
+    : "";
 
   return (
     <button
       onClick={onClick}
-      className="w-full text-left rounded-2xl overflow-hidden shadow-sm border transition-transform active:scale-[0.98]"
-      style={{ borderColor: BRAND.border, backgroundColor: BRAND.surface }}
+      className="flex-shrink-0 w-[200px] rounded-[18px] overflow-hidden text-left transition-transform active:scale-[0.97]"
+      style={{
+        backgroundColor: BRAND.surface,
+        boxShadow: "0 2px 8px rgba(0,0,0,0.06)",
+      }}
     >
-      {/* Colored top bar */}
-      <div className="h-1.5" style={{ backgroundColor: color }} />
-
+      {/* Image placeholder with gradient */}
+      <div
+        className="relative h-[110px]"
+        style={{ background: `linear-gradient(135deg, ${gradient[0]}, ${gradient[1]})` }}
+      >
+        <div className="absolute inset-0 bg-black/10" />
+        {/* Date badge */}
+        {dateLabel && (
+          <span className="absolute top-2.5 left-2.5 px-2 py-0.5 rounded-full bg-white text-[10px] font-bold" style={{ color: BRAND.textPrimary }}>
+            {dateLabel}
+          </span>
+        )}
+        {/* Free badge */}
+        {isFree && (
+          <span
+            className="absolute bottom-2.5 left-2.5 px-2 py-0.5 rounded-full text-[9px] font-bold"
+            style={{ backgroundColor: BRAND.yellow, color: BRAND.onPrimary }}
+          >
+            Gratis
+          </span>
+        )}
+      </div>
       <div className="p-3">
-        {/* Category badge */}
-        <span
-          className="inline-block text-[9px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full mb-1.5"
-          style={{ backgroundColor: tint, color }}
-        >
-          {event.categories?.[0]?.name ?? "Event"}
-        </span>
-
         <h3
-          className="text-[13px] font-semibold leading-snug line-clamp-2 mb-1.5 break-words"
+          className="text-[13px] font-semibold leading-snug line-clamp-2 mb-1"
           style={{ color: BRAND.textPrimary }}
         >
           {event.title}
         </h3>
+        <span className="flex items-center gap-1 text-[11px]" style={{ color: BRAND.textSecondary }}>
+          <MapPin size={10} />
+          {event.city}
+        </span>
+      </div>
+    </button>
+  );
+}
 
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px]" style={{ color: BRAND.textSecondary }}>
-          {event.city && (
-            <span className="flex items-center gap-1">
-              <MapPin size={11} className="flex-shrink-0" />
-              <span className="truncate max-w-[120px]">{event.city}</span>
+function FeaturedCard({ event, onClick }: { event: EventDto; onClick: () => void }) {
+  const catCode = event.categories?.[0]?.code ?? 1;
+  const gradient = CATEGORY_GRADIENTS[catCode] ?? CATEGORY_GRADIENTS[1];
+  const dateLabel = event.startDate
+    ? format(new Date(event.startDate), "d MMM yyyy", { locale: sv })
+    : "";
+
+  return (
+    <button
+      onClick={onClick}
+      className="w-full text-left rounded-[18px] overflow-hidden transition-transform active:scale-[0.98]"
+      style={{
+        /* RGB animated border effect (static version for web) */
+        padding: "2.5px",
+        background: `linear-gradient(135deg, ${BRAND.yellow}, #F87171, #A78BFA, #60A5FA, #FB923C, #F472B6, ${BRAND.yellow})`,
+        backgroundSize: "400% 400%",
+        animation: "rgbShift 4s ease infinite",
+      }}
+    >
+      <div
+        className="relative h-[160px] rounded-[16px] overflow-hidden"
+        style={{ background: `linear-gradient(135deg, ${gradient[0]}, ${gradient[1]})` }}
+      >
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="absolute bottom-0 left-0 right-0 p-4">
+          {dateLabel && (
+            <span className="inline-block px-2.5 py-0.5 rounded-full bg-white text-[10px] font-bold mb-2" style={{ color: BRAND.textPrimary }}>
+              {dateLabel}
             </span>
           )}
-          <span className="flex items-center gap-1">
-            <CalendarDays size={11} className="flex-shrink-0" />
-            {dateLabel}
+          <h3 className="text-[17px] font-bold text-white leading-snug" style={{ textShadow: "0 1px 4px rgba(0,0,0,0.3)" }}>
+            {event.title}
+          </h3>
+          <span className="flex items-center gap-1 text-[11px] text-white/80 mt-0.5">
+            <MapPin size={10} />
+            {event.city}
           </span>
         </div>
       </div>

--- a/src/components/preview/screens/ResultsScreen.tsx
+++ b/src/components/preview/screens/ResultsScreen.tsx
@@ -8,15 +8,29 @@ import {
   CATEGORY_COLORS,
   CATEGORY_TINTS,
   CATEGORY_SHORT_LABELS,
+  CATEGORY_EMOJIS,
+  MOCK_LOCATIONS,
+  HELSINGBORG_CENTER,
 } from "../constants";
 import { filterMockEvents } from "../mockEvents";
-import { ArrowLeft, MapPin, CalendarDays } from "lucide-react";
+import {
+  ArrowLeft,
+  MapPin,
+  CalendarDays,
+  Navigation,
+  ArrowUpDown,
+  SlidersHorizontal,
+  Map as MapIcon,
+  List,
+} from "lucide-react";
 import { format } from "date-fns";
 import { sv } from "date-fns/locale";
 
 interface ResultsScreenProps {
   categoryCode: number;
   tagCodes: number[];
+  showMap: boolean;
+  onToggleMap: () => void;
   onTagsChange: (tagCodes: number[]) => void;
   onBack: () => void;
   onSelectEvent: (eventId: string) => void;
@@ -25,11 +39,17 @@ interface ResultsScreenProps {
 export function ResultsScreen({
   categoryCode,
   tagCodes,
+  showMap,
+  onToggleMap,
   onTagsChange,
   onBack,
   onSelectEvent,
 }: ResultsScreenProps) {
   const [selectedSub, setSelectedSub] = useState<number | null>(null);
+  const [nearMe, setNearMe] = useState(false);
+  const [showSort, setShowSort] = useState(false);
+  const [showFilter, setShowFilter] = useState(false);
+
   const category = categoryOptions.find((c) => c.code === categoryCode);
   const subcategories = subcategoriesMap[categoryCode] ?? [];
   const color = CATEGORY_COLORS[categoryCode] ?? CATEGORY_COLORS[1];
@@ -37,52 +57,145 @@ export function ResultsScreen({
 
   const toggleTag = (code: number) => {
     onTagsChange(
-      tagCodes.includes(code)
-        ? tagCodes.filter((c) => c !== code)
-        : [...tagCodes, code]
+      tagCodes.includes(code) ? tagCodes.filter((c) => c !== code) : [...tagCodes, code],
     );
   };
 
   const { items: events, totalCount } = useMemo(
-    () => filterMockEvents({
-      categoryCodes: [categoryCode],
-      subcategoryCodes: selectedSub ? [selectedSub] : undefined,
-      tagCodes: tagCodes.length > 0 ? tagCodes : undefined,
-      pageSize: 12,
-    }),
+    () =>
+      filterMockEvents({
+        categoryCodes: [categoryCode],
+        subcategoryCodes: selectedSub ? [selectedSub] : undefined,
+        tagCodes: tagCodes.length > 0 ? tagCodes : undefined,
+        pageSize: 15,
+      }),
     [categoryCode, selectedSub, tagCodes],
   );
 
   return (
-    <div>
-      {/* Header */}
-      <div className="px-4 pt-1 pb-3" style={{ backgroundColor: tint, borderBottom: `1px solid ${color}25` }}>
-        <button
-          onClick={onBack}
-          className="flex items-center gap-1 text-[13px] font-medium mb-2 active:opacity-70"
-          style={{ color }}
-        >
-          <ArrowLeft size={16} />
-          Tillbaka
-        </button>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            {category && (
-              <category.icon size={20} color={color} strokeWidth={2} />
-            )}
-            <h1 className="text-[17px] font-bold" style={{ color }}>
-              {CATEGORY_SHORT_LABELS[categoryCode] ?? category?.label}
-            </h1>
+    <div style={{ backgroundColor: BRAND.background }}>
+      {/* Compact header */}
+      <div className="px-4 pt-1 pb-2" style={{ backgroundColor: BRAND.surface, borderBottom: `1px solid ${BRAND.border}` }}>
+        <div className="flex items-center gap-2 mb-1.5">
+          <button
+            onClick={onBack}
+            className="w-[34px] h-[34px] flex items-center justify-center rounded-full active:opacity-70"
+            style={{ backgroundColor: BRAND.neutral100 }}
+          >
+            <ArrowLeft size={16} style={{ color: BRAND.textBody }} />
+          </button>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5">
+              {category && <category.icon size={16} color={color} strokeWidth={2} />}
+              <h1 className="text-[15px] font-bold truncate" style={{ color: BRAND.textPrimary }}>
+                {CATEGORY_SHORT_LABELS[categoryCode] ?? category?.label}
+              </h1>
+            </div>
           </div>
-          <span className="text-[11px] font-medium" style={{ color: BRAND.textSecondary }}>
-            {totalCount} evenemang
+          <span
+            className="text-[11px] font-medium px-2 py-0.5 rounded-full"
+            style={{ backgroundColor: BRAND.neutral100, color: BRAND.textSecondary }}
+          >
+            {totalCount}
           </span>
         </div>
+
+        {/* Inline filter chips */}
+        {(selectedSub || tagCodes.length > 0) && (
+          <div className="flex gap-1 overflow-x-auto pb-1 scrollbar-hide">
+            {selectedSub && (
+              <span
+                className="flex-shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold"
+                style={{ backgroundColor: BRAND.yellow, color: BRAND.onPrimary }}
+              >
+                {subcategories.find((s) => s.code === selectedSub)?.label}
+              </span>
+            )}
+            {tagCodes.map((tc) => {
+              const tag = filterOptions.find((f) => f.code === tc);
+              return (
+                <span
+                  key={tc}
+                  className="flex-shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold"
+                  style={{ backgroundColor: BRAND.yellow, color: BRAND.onPrimary }}
+                >
+                  {tag?.label}
+                </span>
+              );
+            })}
+          </div>
+        )}
       </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center gap-1.5 px-4 py-2" style={{ backgroundColor: BRAND.surface }}>
+        <ToolbarPill
+          active={nearMe}
+          onClick={() => setNearMe(!nearMe)}
+          icon={<Navigation size={13} />}
+          label="Nära mig"
+        />
+        <ToolbarPill
+          active={showSort}
+          onClick={() => { setShowSort(!showSort); setShowFilter(false); }}
+          icon={<ArrowUpDown size={13} />}
+          label="Sortera"
+        />
+        <ToolbarPill
+          active={showFilter}
+          onClick={() => { setShowFilter(!showFilter); setShowSort(false); }}
+          icon={<SlidersHorizontal size={13} />}
+          label="Filter"
+        />
+        <div className="flex-1" />
+        <button
+          onClick={onToggleMap}
+          className="w-[34px] h-[34px] flex items-center justify-center rounded-full transition-colors"
+          style={{
+            backgroundColor: showMap ? BRAND.yellow : BRAND.neutral100,
+            color: showMap ? BRAND.onPrimary : BRAND.textSecondary,
+          }}
+        >
+          {showMap ? <List size={15} /> : <MapIcon size={15} />}
+        </button>
+      </div>
+
+      {/* Sort dropdown */}
+      {showSort && (
+        <div className="mx-4 mb-2 rounded-xl overflow-hidden border" style={{ borderColor: BRAND.border, backgroundColor: BRAND.surface }}>
+          {["Datum (närmast)", "Datum (längst bort)", "A-Ö"].map((opt) => (
+            <button key={opt} className="w-full text-left px-4 py-2.5 text-[12px] font-medium hover:bg-gray-50 transition-colors" style={{ color: BRAND.textBody }}>
+              {opt}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Filter tags dropdown */}
+      {showFilter && (
+        <div className="flex gap-1.5 flex-wrap px-4 pb-2">
+          {filterOptions.map((tag) => {
+            const active = tagCodes.includes(tag.code);
+            return (
+              <button
+                key={tag.code}
+                onClick={() => toggleTag(tag.code)}
+                className="flex-shrink-0 px-3 py-1.5 rounded-full text-[11px] font-medium transition-colors"
+                style={{
+                  backgroundColor: active ? BRAND.yellow : BRAND.neutral100,
+                  color: active ? BRAND.onPrimary : BRAND.textSecondary,
+                }}
+              >
+                {tag.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
 
       {/* Subcategory filter chips */}
       {subcategories.length > 0 && (
-        <div className="flex gap-1.5 overflow-x-auto px-4 py-2.5 scrollbar-hide">
+        <div className="flex gap-1.5 overflow-x-auto px-4 py-2 scrollbar-hide">
           <button
             onClick={() => setSelectedSub(null)}
             className="flex-shrink-0 px-3 py-1.5 rounded-full text-[11px] font-semibold transition-colors"
@@ -114,46 +227,191 @@ export function ResultsScreen({
         </div>
       )}
 
-      {/* Tag filter chips */}
-      <div className="flex gap-1.5 flex-wrap px-4 pb-2">
-        {filterOptions.map((tag) => {
-          const active = tagCodes.includes(tag.code);
-          return (
-            <button
-              key={tag.code}
-              onClick={() => toggleTag(tag.code)}
-              className="flex-shrink-0 px-2.5 py-1 rounded-full text-[10px] font-semibold transition-colors"
-              style={{
-                backgroundColor: active ? BRAND.textPrimary : BRAND.surface,
-                color: active ? "#FFFFFF" : BRAND.textSecondary,
-                border: `1px solid ${active ? BRAND.textPrimary : BRAND.border}`,
-              }}
-            >
-              {tag.label}
-            </button>
-          );
-        })}
+      {/* Content: Map or List */}
+      {showMap ? (
+        <MapView events={events} categoryCode={categoryCode} onSelectEvent={onSelectEvent} />
+      ) : (
+        <div className="px-4 pb-4">
+          <div className="flex flex-col gap-2 mt-1">
+            {events.map((event) => (
+              <ResultCard
+                key={event.id}
+                event={event}
+                accentColor={color}
+                tint={tint}
+                onClick={() => onSelectEvent(event.id)}
+              />
+            ))}
+          </div>
+
+          {events.length === 0 && (
+            <p className="text-center text-[12px] py-8" style={{ color: BRAND.textSecondary }}>
+              Inga evenemang i denna kategori
+            </p>
+          )}
+
+          {/* Pagination stub */}
+          {events.length > 0 && (
+            <div className="flex items-center justify-center gap-1.5 mt-4">
+              <span className="text-[10px]" style={{ color: BRAND.textSecondary }}>
+                Visar 1-{events.length} av {totalCount}
+              </span>
+              <div className="flex gap-1 ml-2">
+                {[1, 2, 3].map((p) => (
+                  <button
+                    key={p}
+                    className="w-[30px] h-[30px] rounded-lg text-[11px] font-semibold flex items-center justify-center"
+                    style={{
+                      backgroundColor: p === 1 ? BRAND.yellow : BRAND.neutral100,
+                      color: p === 1 ? BRAND.onPrimary : BRAND.textSecondary,
+                    }}
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Provider info */}
+          <div className="mt-3 text-center">
+            <p className="text-[9px]" style={{ color: BRAND.neutral300 }}>
+              Data: Go.Do + Helsingborg Events API
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToolbarPill({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-center gap-1 px-3 h-[34px] rounded-full text-[11px] font-medium transition-colors"
+      style={{
+        backgroundColor: active ? BRAND.yellow : BRAND.neutral100,
+        color: active ? BRAND.onPrimary : BRAND.textSecondary,
+      }}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function MapView({
+  events,
+  categoryCode,
+  onSelectEvent,
+}: {
+  events: EventDto[];
+  categoryCode: number;
+  onSelectEvent: (eventId: string) => void;
+}) {
+  const color = CATEGORY_COLORS[categoryCode] ?? CATEGORY_COLORS[1];
+  const emoji = CATEGORY_EMOJIS[categoryCode] ?? "📍";
+
+  // Group events by city for pin placement
+  const cityGroups = useMemo(() => {
+    const groups: Record<string, { events: EventDto[]; loc: { lat: number; lng: number } }> = {};
+    for (const ev of events) {
+      const city = ev.city || "Helsingborg";
+      if (!groups[city]) {
+        groups[city] = {
+          events: [],
+          loc: MOCK_LOCATIONS[city] ?? HELSINGBORG_CENTER,
+        };
+      }
+      groups[city].events.push(ev);
+    }
+    return groups;
+  }, [events]);
+
+  return (
+    <div className="relative" style={{ height: "380px" }}>
+      {/* Map background with grid */}
+      <div
+        className="absolute inset-0"
+        style={{
+          backgroundColor: "#E8F4E8",
+          backgroundImage: `
+            linear-gradient(rgba(255,255,255,0.4) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(255,255,255,0.4) 1px, transparent 1px)
+          `,
+          backgroundSize: "40px 40px",
+        }}
+      >
+        {/* Water areas */}
+        <div className="absolute top-0 right-0 w-[40%] h-[35%] rounded-bl-[60px]" style={{ backgroundColor: "#B3D9F2" }} />
+        <div className="absolute bottom-[10%] left-[5%] w-[15%] h-[12%] rounded-full" style={{ backgroundColor: "#B3D9F2" }} />
+
+        {/* Roads */}
+        <div className="absolute top-[30%] left-0 right-0 h-[2px]" style={{ backgroundColor: "#D1D5DB" }} />
+        <div className="absolute top-0 bottom-0 left-[35%] w-[2px]" style={{ backgroundColor: "#D1D5DB" }} />
+        <div className="absolute top-[60%] left-0 right-[30%] h-[2px]" style={{ backgroundColor: "#D1D5DB" }} />
+        <div className="absolute top-[15%] bottom-[20%] left-[65%] w-[2px]" style={{ backgroundColor: "#D1D5DB" }} />
       </div>
 
-      {/* Results */}
-      <div className="px-4 pb-4">
-        <div className="flex flex-col gap-2.5 mt-1">
-          {events.map((event) => (
-            <ResultCard
-              key={event.id}
-              event={event}
-              accentColor={color}
-              tint={tint}
-              onClick={() => onSelectEvent(event.id)}
-            />
-          ))}
-        </div>
+      {/* Map pins */}
+      {Object.entries(cityGroups).map(([city, { events: cityEvents }], i) => {
+        // Position pins roughly based on city
+        const positions: Record<string, { top: string; left: string }> = {
+          Helsingborg: { top: "30%", left: "40%" },
+          "Malmö": { top: "65%", left: "55%" },
+          Lund: { top: "55%", left: "30%" },
+        };
+        const pos = positions[city] ?? { top: `${30 + i * 20}%`, left: `${30 + i * 15}%` };
 
-        {events.length === 0 && (
-          <p className="text-center text-[12px] py-8" style={{ color: BRAND.textSecondary }}>
-            Inga evenemang i denna kategori
-          </p>
-        )}
+        return (
+          <button
+            key={city}
+            onClick={() => cityEvents[0] && onSelectEvent(cityEvents[0].id)}
+            className="absolute flex flex-col items-center -translate-x-1/2 -translate-y-full z-10 group"
+            style={{ top: pos.top, left: pos.left }}
+          >
+            {/* Pin bubble */}
+            <div
+              className="relative px-2 py-1 rounded-xl flex items-center gap-1 shadow-md transition-transform group-hover:scale-110"
+              style={{ backgroundColor: color }}
+            >
+              <span className="text-[12px]">{emoji}</span>
+              <span className="text-[10px] font-bold text-white">{cityEvents.length}</span>
+              {/* Pin arrow */}
+              <div
+                className="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-0 h-0"
+                style={{
+                  borderLeft: "5px solid transparent",
+                  borderRight: "5px solid transparent",
+                  borderTop: `6px solid ${color}`,
+                }}
+              />
+            </div>
+            {/* City label */}
+            <span
+              className="text-[9px] font-semibold mt-2 px-1.5 py-0.5 rounded bg-white/90 shadow-sm"
+              style={{ color: BRAND.textPrimary }}
+            >
+              {city}
+            </span>
+          </button>
+        );
+      })}
+
+      {/* Map attribution */}
+      <div className="absolute bottom-2 right-2 text-[8px] px-1.5 py-0.5 rounded bg-white/80" style={{ color: BRAND.textSecondary }}>
+        Go.Do Map Preview
       </div>
     </div>
   );
@@ -179,31 +437,45 @@ function ResultCard({
   return (
     <button
       onClick={onClick}
-      className="w-full text-left rounded-2xl overflow-hidden shadow-sm border transition-transform active:scale-[0.98]"
-      style={{ borderColor: BRAND.border, backgroundColor: BRAND.surface }}
+      className="w-full text-left rounded-[18px] overflow-hidden border transition-transform active:scale-[0.98]"
+      style={{
+        borderColor: BRAND.border,
+        backgroundColor: BRAND.surface,
+        boxShadow: "0 1px 3px rgba(0,0,0,0.04)",
+      }}
     >
       <div className="flex">
         {/* Color strip */}
         <div className="w-1.5 flex-shrink-0" style={{ backgroundColor: accentColor }} />
 
         <div className="flex-1 p-3 min-w-0">
-          <h3
-            className="text-[13px] font-semibold leading-snug line-clamp-2 mb-1 break-words"
-            style={{ color: BRAND.textPrimary }}
-          >
-            {event.title}
-          </h3>
+          {/* Colored dot + title */}
+          <div className="flex items-start gap-2 mb-1">
+            <div
+              className="w-[14px] h-[14px] rounded-full flex-shrink-0 mt-0.5"
+              style={{ backgroundColor: accentColor }}
+            />
+            <h3
+              className="text-[13px] font-semibold leading-snug line-clamp-2 break-words"
+              style={{ color: BRAND.textPrimary, letterSpacing: "0.25px" }}
+            >
+              {event.title}
+            </h3>
+          </div>
 
           {event.subcategories?.[0] && (
             <span
-              className="inline-block text-[9px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full mb-1.5"
+              className="inline-block text-[9px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full mb-1.5 ml-[22px]"
               style={{ backgroundColor: tint, color: accentColor }}
             >
               {event.subcategories[0].name}
             </span>
           )}
 
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px]" style={{ color: BRAND.textSecondary }}>
+          <div
+            className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] ml-[22px]"
+            style={{ color: BRAND.textSecondary }}
+          >
             {event.city && (
               <span className="flex items-center gap-1">
                 <MapPin size={11} className="flex-shrink-0" />


### PR DESCRIPTION
## Summary
- Rewrites all 4 preview screen components (HomeScreen, ResultsScreen, EventDetailScreen, AppPreview) to match the Expo app's `accessibility-redesign` branch design
- Updates design tokens in `constants.ts` to match Expo's WCAG 2.1 AAA color system: Go.Do Yellow (#F3C10E) brand, AAA-contrast category colors, soft tints, gradient pairs
- Updates `PhoneFrame.tsx` background to warm off-white (#FAF8F3)
- Adds `@keyframes rgbShift` CSS animation for the featured card's RGB border effect

### HomeScreen
- Location header with MapPin + notification bell
- Greeting text, search bar, date picker pill
- Category tiles (80x90 with checkmarks on selection)
- Tag filter chips (pill-shaped, yellow when active)
- Go.Do! button with shadow
- Horizontal upcoming event cards with gradient placeholders
- Featured card with animated RGB border

### ResultsScreen
- Compact header with back button, category icon, title, count badge
- Toolbar: Near Me, Sort, Filter pills + Map/List toggle
- Subcategory filter chips
- Styled map view with green terrain, blue water, gray roads, emoji city pins with count badges
- Result cards with colored accent strip and subcategory badges
- Pagination and provider attribution

### EventDetailScreen
- Hero gradient (260dp) with dark scrim overlay
- Floating back + share buttons (40dp white circles)
- White pill tag badges on hero
- Content sheet overlapping hero (-20px, rounded 24px top corners)
- Title (24px bold), category meta, date (16px semibold)
- About, Organiser, Location, Schedule sections with icon circles
- Source attribution divider
- Sticky CTA bar with pill button (Boka biljetter / Besök webbplats / Vägbeskrivning)

## Test plan
- [x] `npx next build` passes with no errors
- [ ] Visual review: open `/preview` page and navigate through all screens
- [ ] Verify category tile selection with checkmarks works
- [ ] Verify map view displays with city pins
- [ ] Verify event detail shows hero gradient + floating buttons + sticky CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)