### PR TITLE
Add comprehensive developer docs and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,232 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# GODO Frontend (Website)
 
-## Getting Started
+> Next.js 16 organiser-facing website for the GODO event management platform.
 
-First, run the development server:
+The frontend website is where event organisers create, manage, and promote events. It's part of a 3-repo platform — this website talks to the backend API, which also serves the mobile app.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+## Platform Overview
+
+```mermaid
+graph TB
+    subgraph Clients
+        FE["Website (Next.js)<br/>(This Repo)"]
+        APP["Mobile App (Expo)<br/>Users browse events"]
+    end
+
+    subgraph "GleSYS VPS"
+        CADDY["Caddy (Reverse Proxy + TLS)"]
+        API[".NET 10 API (Docker)"]
+        DB["SQL Server 2022 (Docker)"]
+    end
+
+    FE -->|HTTPS| CADDY
+    APP -->|HTTPS| CADDY
+    CADDY --> API
+    API --> DB
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+GODO is a **multi-city event management platform** — currently live with Helsingborg as the first integrated city, built to scale across Scandinavia and eventually Europe.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+| Repo | Tech | Purpose | URL |
+|------|------|---------|-----|
+| [**Frontend**](https://github.com/Go-Do-AB/Frontend) | Next.js 16 | Organiser website (this repo) | `godo-dev.nu` |
+| [**Backend**](https://github.com/Go-Do-AB/Backend) | .NET 10 | API server | `api.godo-dev.nu` |
+| [**MobileApp**](https://github.com/Go-Do-AB/MobileApp) | Expo | User mobile app | App stores (upcoming) |
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+---
 
-## Learn More
+## Quick Start
 
-To learn more about Next.js, take a look at the following resources:
+```bash
+# 1. Clone
+git clone https://github.com/Go-Do-AB/Frontend.git
+cd Frontend
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+# 2. Install dependencies
+npm install
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+# 3. Configure API URL
+echo "NEXT_PUBLIC_API_URL=http://localhost:5198/api" > .env.local
 
-## Deploy on Vercel
+# 4. Run dev server
+npm run dev
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Open [http://localhost:3000](http://localhost:3000). Log in with `martina-godo` / `martina-godo1`.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+> **Note:** The [backend API](https://github.com/Go-Do-AB/Backend) must be running for the frontend to work.
+
+---
+
+## Tech Stack
+
+| Technology | Version | Purpose |
+|-----------|---------|---------|
+| Next.js | 16.1.4 | App Router, SSR, Turbopack |
+| React | 19 | UI framework |
+| TypeScript | 5.x | Type safety |
+| Tailwind CSS | 4.x | Utility-first styling |
+| shadcn/ui | - | Pre-built Radix + Tailwind components |
+| TanStack Query | 5.x | Server state management |
+| React Hook Form | 7.x | Form state management |
+| Zod | 4.x | Schema validation |
+| Axios | 1.x | HTTP client with JWT interceptor |
+
+---
+
+## Features
+
+### Event Creation (5-Step Form)
+
+```mermaid
+graph LR
+    S1["1. Details<br/>Title, Categories"] --> S2["2. Location<br/>Address, GPS"]
+    S2 --> S3["3. Date/Time<br/>Single, Recurring"]
+    S3 --> S4["4. Spotlight<br/>Promotion"]
+    S4 --> S5["5. Review<br/>Submit"]
+```
+
+- Per-step Zod validation
+- Same form for create and edit
+- Category/subcategory selection matching backend (8 categories, 24 subcategories)
+
+### Organiser Dashboard
+- **My Events** — View, edit, and soft-delete events
+- **Quick Create** — Admin-only simplified form for places/attractions
+
+### Authentication
+- JWT-based via backend organiser endpoints
+- Token stored in `localStorage`, added to requests via Axios interceptor
+- Role-based UI (Admin sees Quick Create)
+
+---
+
+## Project Structure
+
+```
+src/
+├── app/                          # Pages (App Router)
+│   ├── (auth)/login/             # Organiser login
+│   ├── (auth)/register/          # Organiser registration
+│   ├── landing/                  # Main hub after login
+│   ├── create-event/             # 5-step event form
+│   ├── my-events/                # Organiser dashboard
+│   │   └── [id]/edit/            # Edit event
+│   ├── quick-create/             # Admin-only quick form
+│   └── preview/                  # Mobile app mockup
+│
+├── components/
+│   ├── forms/EventFormStepper.tsx # Multi-step form orchestrator
+│   ├── forms/steps/              # 5 step components
+│   ├── global/Navbar.tsx         # Navigation bar
+│   ├── events/                   # Event display components
+│   ├── preview/                  # Mobile app mockup
+│   └── ui/                       # shadcn/ui components
+│
+├── hooks/                        # TanStack Query hooks (CRUD)
+├── lib/
+│   ├── axios.ts                  # Shared HTTP client + JWT
+│   ├── content/contentText.tsx   # Category definitions (must match backend)
+│   └── validation/               # Zod schemas + payload transformers
+└── types/events.ts               # TypeScript interfaces (matches backend DTOs)
+```
+
+---
+
+## API Integration
+
+All API calls use the shared Axios instance with JWT interceptor:
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/api/organisers/auth/login` | Organiser login |
+| POST | `/api/organisers/auth/register` | Organiser registration |
+| GET | `/api/events` | List events (with filters) |
+| GET | `/api/events/{id}` | Get single event |
+| POST | `/api/events` | Create event |
+| PUT | `/api/events/{id}` | Full update event |
+| PATCH | `/api/events/{id}` | Partial update event |
+| DELETE | `/api/events/{id}` | Soft delete event |
+| POST | `/api/events/quick` | Quick-create (Admin) |
+
+---
+
+## CI/CD Pipeline
+
+```mermaid
+graph LR
+    subgraph "PR Checks"
+        A["Install"] --> B["Lint"]
+        B --> C["Type Check"]
+        C --> D["Build"]
+    end
+
+    subgraph "Merge to main"
+        E["Docker Build"] --> F["Deploy to GleSYS"]
+    end
+```
+
+- **PR checks:** `npm ci` → ESLint → TypeScript → `npm run build`
+- **Deploy:** Docker multi-stage build, deployed to GleSYS behind Caddy
+
+---
+
+## Development
+
+```bash
+npm run dev        # Dev server (Turbopack)
+npm run build      # Production build
+npm run lint       # ESLint
+npm run format     # Prettier
+npx tsc --noEmit   # Type check
+```
+
+---
+
+## Documentation
+
+### Developer Guides (start here if you're new)
+
+| Guide | Description |
+|-------|-------------|
+| [Getting Started](forDevelopers/GETTING-STARTED.md) | Clone, install, run |
+| [Project Walkthrough](forDevelopers/PROJECT-WALKTHROUGH.md) | Visual codebase tour |
+| [Form Guide](forDevelopers/FORM-GUIDE.md) | Multi-step event form deep-dive |
+| [Development Workflow](forDevelopers/DEVELOPMENT-WORKFLOW.md) | Branching, linting, PRs |
+
+### Reference Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Onboarding](docs/ONBOARDING.md) | 15-minute project orientation |
+| [Architecture](docs/ARCHITECTURE.md) | System design with diagrams |
+| [Docs Hub](docs/README.md) | Documentation index |
+
+### Other Repos
+
+| Repo | Description |
+|------|-------------|
+| [Backend](https://github.com/Go-Do-AB/Backend) | .NET 10 API |
+| [MobileApp](https://github.com/Go-Do-AB/MobileApp) | Expo mobile app |
+
+---
+
+## Contributing
+
+1. Create a feature branch from `main`
+2. Make changes
+3. Ensure `npm run lint` and `npm run build` pass
+4. Submit a pull request
+
+See [Development Workflow](forDevelopers/DEVELOPMENT-WORKFLOW.md) for details.
+
+---
+
+## Environment
+
+| Environment | URL | Purpose |
+|-------------|-----|---------|
+| Local | `http://localhost:3000` | Development |
+| Production | `https://godo-dev.nu` | GleSYS VPS |
+| Backend (local) | `http://localhost:5198` | API server |
+| Backend (prod) | `https://api.godo-dev.nu` | API server |

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,120 @@
+# Onboarding
+
+> Get oriented with the GODO Frontend in 15 minutes. No setup required — just read.
+
+## What is GODO?
+
+GODO is a **multi-city event management platform** that helps people discover things to do. Currently live with Helsingborg as the first integrated city, the platform is built to scale across Scandinavia and eventually Europe.
+
+This repo is the **organiser-facing website** — where event organisers create, manage, and promote their events.
+
+```mermaid
+graph TB
+    FE["Website (Next.js)<br/>(This Repo)<br/>Organisers use this"]
+    APP["Mobile App (Expo)<br/>Users browse events"]
+    API[".NET 10 Backend API"]
+    DB[(SQL Server)]
+
+    FE -->|"Create/edit/delete events"| API
+    APP -->|"Browse/filter events"| API
+    API --> DB
+```
+
+## What Does the Frontend Do?
+
+The website has 5 main functions:
+
+```mermaid
+graph TB
+    LOGIN["Login / Register<br/>(Organiser auth)"]
+    CREATE["Create Event<br/>(5-step form)"]
+    MY["My Events<br/>(Dashboard)"]
+    EDIT["Edit Event<br/>(Same form, pre-filled)"]
+    QUICK["Quick Create<br/>(Admin only)"]
+
+    LOGIN --> CREATE
+    LOGIN --> MY
+    LOGIN --> QUICK
+    MY --> EDIT
+```
+
+1. **Login/Register** — Organisers authenticate with JWT tokens
+2. **Create Event** — A 5-step form: Details → Location → Date/Time → Spotlight → Review
+3. **My Events** — Dashboard showing the organiser's events, with edit and delete
+4. **Edit Event** — Same form as create, pre-filled with existing data
+5. **Quick Create** — Simplified form for admins to quickly add places/attractions
+
+## Tech Stack at a Glance
+
+| Technology | Purpose |
+|-----------|---------|
+| Next.js 16 | App Router, pages, server-side rendering |
+| React 19 | UI components |
+| TypeScript | Type safety |
+| Tailwind CSS | Styling |
+| shadcn/ui | Pre-built UI components |
+| TanStack Query | API data fetching and caching |
+| React Hook Form + Zod | Form state + validation |
+| Axios | HTTP client with JWT interceptor |
+
+## Folder Structure at a Glance
+
+```
+src/
+├── app/              → Pages (login, landing, create-event, my-events, etc.)
+├── components/       → React components (forms, UI, navbar, preview)
+├── hooks/            → Data fetching hooks (useEvents, useCreateEvent, etc.)
+├── lib/              → Utilities, Axios config, validation schemas, category data
+├── providers/        → React Query provider
+└── types/            → TypeScript interfaces (must match backend DTOs)
+```
+
+## 5 Most Important Files
+
+| # | File | What It Does |
+|---|------|-------------|
+| 1 | `src/lib/axios.ts` | Shared HTTP client — adds JWT token to all requests |
+| 2 | `src/components/forms/EventFormStepper.tsx` | The 5-step form orchestrator — most complex component |
+| 3 | `src/lib/validation/create-event-schema.ts` | Zod schema + transforms form data to API format |
+| 4 | `src/hooks/useEvents.ts` | All CRUD hooks — how data is fetched and mutated |
+| 5 | `src/lib/content/contentText.tsx` | Category/subcategory/tag definitions (must match backend) |
+
+## Key Concepts
+
+### API Communication
+- All API calls go through a shared Axios instance (`src/lib/axios.ts`)
+- JWT token is stored in `localStorage` and automatically added to every request
+- All responses use `OperationResult<T>` format: `{ isSuccess, data, errors }`
+
+### The Event Form
+- 5 steps with per-step validation (can't skip ahead)
+- Zod schema validates, `createPayload()` transforms to API format
+- Same form is used for both create and edit (edit pre-fills via `eventDtoToFormData()`)
+
+### Categories Must Match Backend
+- Category/subcategory/tag definitions are hardcoded in `contentText.tsx`
+- These **must exactly match** the backend's DataSeeder
+- Subcategory codes follow the pattern: `categoryCode * 100 + index`
+
+### Authentication
+- Organisers log in via `POST /api/organisers/auth/login`
+- JWT stored in `localStorage` as `accessToken`
+- Axios interceptor adds `Authorization: Bearer <token>` to all requests
+- Admin role decoded from JWT for admin-only features (Quick Create)
+
+## Common Mistakes to Avoid
+
+| Mistake | Why It's Wrong | Do This Instead |
+|---------|---------------|-----------------|
+| Use raw `fetch()` | Bypasses JWT interceptor | Use the shared `api` from `lib/axios.ts` |
+| Hardcode API URLs | Breaks in production | Use `NEXT_PUBLIC_API_URL` env var |
+| Forget to update `contentText.tsx` | Categories won't match backend | Keep in sync with backend DataSeeder |
+| Skip Zod validation | Form can submit invalid data | Always validate through schema |
+| Store sensitive data in `localStorage` | Security risk | Only store JWT tokens |
+
+## What's Next
+
+1. **[forDevelopers/Getting Started](../forDevelopers/GETTING-STARTED.md)** — Clone, install, and run
+2. **[forDevelopers/Project Walkthrough](../forDevelopers/PROJECT-WALKTHROUGH.md)** — Visual tour of the codebase
+3. **[forDevelopers/Form Guide](../forDevelopers/FORM-GUIDE.md)** — How the event form works
+4. **[ARCHITECTURE.md](ARCHITECTURE.md)** — Full architecture with diagrams

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,45 @@
+# Documentation Hub
+
+> All documentation for the GODO Frontend (Website).
+
+## Quick Reference
+
+| Document | What It Covers |
+|----------|----------------|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | System design — tech stack, data flow, deployment, form architecture |
+| [ONBOARDING.md](ONBOARDING.md) | 15-minute orientation for new team members |
+
+## Developer Guides
+
+Hands-on tutorials and walkthroughs live in [`forDevelopers/`](../forDevelopers/README.md):
+
+| Guide | Purpose |
+|-------|---------|
+| [Getting Started](../forDevelopers/GETTING-STARTED.md) | Zero to running dev server |
+| [Project Walkthrough](../forDevelopers/PROJECT-WALKTHROUGH.md) | Visual codebase tour |
+| [Form Guide](../forDevelopers/FORM-GUIDE.md) | Multi-step event form deep-dive |
+| [Development Workflow](../forDevelopers/DEVELOPMENT-WORKFLOW.md) | Branching, linting, CI/CD |
+
+## Reading Order
+
+### New Developer
+```mermaid
+graph LR
+    A["1. ONBOARDING.md"] --> B["2. forDevelopers/"]
+    B --> C["3. ARCHITECTURE.md"]
+
+    style A fill:#F3C10E,color:#000
+```
+
+### Day-to-Day Development
+- [ARCHITECTURE.md](ARCHITECTURE.md) — How things are structured
+- [forDevelopers/Form Guide](../forDevelopers/FORM-GUIDE.md) — The event form
+- [Backend API docs](https://github.com/Go-Do-AB/Backend/blob/main/docs/API.md) — API reference
+
+## Cross-Repo Documentation
+
+| Repo | Purpose | Docs |
+|------|---------|------|
+| **[Backend](https://github.com/Go-Do-AB/Backend)** | .NET 10 API | `docs/` and `forDevelopers/` |
+| **[Frontend](https://github.com/Go-Do-AB/Frontend)** | Next.js website (this repo) | You are here |
+| **[MobileApp](https://github.com/Go-Do-AB/MobileApp)** | Expo mobile app | `docs/` and `forDevelopers/` |

--- a/forDevelopers/DEVELOPMENT-WORKFLOW.md
+++ b/forDevelopers/DEVELOPMENT-WORKFLOW.md
@@ -1,0 +1,199 @@
+# Development Workflow
+
+> Day-to-day practices: branching, linting, CI/CD, and submitting PRs.
+
+## Development Cycle
+
+```mermaid
+graph LR
+    A["Create Branch"] --> B["Write Code"]
+    B --> C["Lint & Format"]
+    C --> D["Commit"]
+    D --> E["Push & PR"]
+    E --> F["CI Checks"]
+    F --> G["Review & Merge"]
+
+    style A fill:#F3C10E,color:#000
+    style G fill:#F3C10E,color:#000
+```
+
+---
+
+## Branch Strategy
+
+| Branch | Purpose | Example |
+|--------|---------|---------|
+| `main` | Production-ready code | Always deployable |
+| `feature/*` | New features | `feature/add-search` |
+| `fix/*` | Bug fixes | `fix/date-picker-bug` |
+| `chore/*` | Maintenance, deps, docs | `chore/update-deps` |
+
+**Rules:**
+- Never push directly to `main`
+- All changes go through pull requests
+- Branch from `main`, merge back to `main`
+
+---
+
+## Available Scripts
+
+```bash
+npm run dev        # Start dev server (Turbopack)
+npm run build      # Production build
+npm run start      # Start production server
+npm run lint       # ESLint check
+npm run format     # Prettier format all files
+```
+
+---
+
+## Making Changes
+
+### Adding a New Page
+
+1. Create `src/app/your-page/page.tsx`
+2. Next.js automatically routes to `/your-page`
+3. Add navigation link in `Navbar.tsx` if needed
+
+### Adding a New Component
+
+1. Create in the appropriate subfolder:
+   - `components/forms/` — form-related
+   - `components/events/` — event display
+   - `components/global/` — site-wide (navbar, footer)
+   - `components/ui/` — shadcn/ui primitives only
+2. Use TypeScript interfaces for props
+3. Import and use in your page
+
+### Adding a New API Hook
+
+1. Create or update a hook in `src/hooks/`
+2. Use TanStack Query's `useQuery` (reads) or `useMutation` (writes)
+3. Use the shared `api` instance from `src/lib/axios.ts`
+4. Type the response with interfaces from `src/types/events.ts`
+
+### Modifying the Event Form
+
+See the [Form Guide](FORM-GUIDE.md) for the full walkthrough. Quick summary:
+1. Update Zod schema in `lib/validation/create-event-schema.ts`
+2. Update the relevant Step component
+3. Update `createPayload()` and `eventDtoToFormData()`
+
+---
+
+## Code Conventions
+
+### Naming
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Components | PascalCase | `EventFormStepper.tsx` |
+| Hooks | camelCase with `use` prefix | `useEvents.ts` |
+| Utilities | camelCase | `formatDate()` |
+| Types/Interfaces | PascalCase | `CreateEventDto` |
+| Pages | `page.tsx` in route folder | `src/app/landing/page.tsx` |
+
+### Styling
+
+- Use **Tailwind CSS** utility classes
+- Use **shadcn/ui** components for common UI elements (Button, Card, Dialog, etc.)
+- Use `cn()` from `lib/utils.ts` to merge class names conditionally
+
+### API Calls
+
+- Always use the shared `api` instance from `lib/axios.ts`
+- Never use raw `fetch()` with hardcoded URLs
+- All responses follow `OperationResult<T>` format
+
+### Categories Must Match Backend
+
+The category/subcategory/tag definitions in `src/lib/content/contentText.tsx` **must match the backend DataSeeder exactly**. If the backend adds a category, the frontend must be updated too.
+
+---
+
+## CI/CD Pipeline
+
+Every pull request triggers GitHub Actions:
+
+```mermaid
+graph LR
+    subgraph "PR Checks"
+        A["Install deps"] --> B["Lint (ESLint)"]
+        B --> C["Type Check (tsc)"]
+        C --> D["Build"]
+    end
+
+    subgraph "After Merge to main"
+        E["Docker Build"] --> F["Push Image"]
+        F --> G["Deploy to GleSYS"]
+    end
+```
+
+### PR Check Pipeline (`pull-request-check-action.yml`)
+
+| Step | Command | Blocks Merge? |
+|------|---------|---------------|
+| Install | `npm ci` | Yes |
+| Lint | `npm run lint` | Yes |
+| Type Check | `npx tsc --noEmit` | Yes |
+| Build | `npm run build` | Yes |
+
+### Deploy Pipeline (`deploy.yml`)
+
+After merge to `main`:
+1. Multi-stage Docker build (Node 20 Alpine)
+2. Push to container registry
+3. Deploy to GleSYS VPS behind Caddy reverse proxy
+4. Available at `https://godo-dev.nu`
+
+---
+
+## PR Checklist
+
+Before submitting a PR, verify:
+
+- [ ] `npm run lint` passes
+- [ ] `npx tsc --noEmit` passes (no type errors)
+- [ ] `npm run build` succeeds
+- [ ] Tested in browser with backend running
+- [ ] No hardcoded API URLs (use `NEXT_PUBLIC_API_URL`)
+- [ ] New components use TypeScript props interfaces
+- [ ] Category changes match backend (if applicable)
+
+---
+
+## Debugging Tips
+
+### API Call Issues
+
+Open browser DevTools → Network tab to see:
+- Request URL (verify `NEXT_PUBLIC_API_URL` is correct)
+- Request headers (verify JWT `Authorization` header is present)
+- Response body (check `isSuccess` and `errors` fields)
+
+### Form Debugging
+
+React Hook Form has a devtools extension. You can also log form state:
+```typescript
+const form = useFormContext();
+console.log(form.getValues());      // Current form data
+console.log(form.formState.errors); // Validation errors
+```
+
+### Common Issues
+
+| Issue | Where to Look |
+|-------|---------------|
+| Login doesn't work | Check `NEXT_PUBLIC_API_URL` in `.env.local` |
+| Form won't submit | Check Zod validation in `create-event-schema.ts` |
+| Categories missing | Compare `contentText.tsx` with backend DataSeeder |
+| JWT expired | Login again — tokens expire in 5 minutes |
+| Edit form empty | Check `eventDtoToFormData()` transformation |
+
+---
+
+## Related Documentation
+
+- **[Form Guide](FORM-GUIDE.md)** — Multi-step form deep-dive
+- **[docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md)** — Full architecture with diagrams
+- **[Backend API docs](https://github.com/Go-Do-AB/Backend/blob/main/docs/API.md)** — API endpoint reference

--- a/forDevelopers/FORM-GUIDE.md
+++ b/forDevelopers/FORM-GUIDE.md
@@ -1,0 +1,235 @@
+# Form Guide
+
+> How the multi-step event creation form works — the most complex part of the frontend.
+
+## Overview
+
+The event form is a **5-step wizard** that lets organisers create events. It handles validation per step, data transformation, and both create and edit modes.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Details: Step 1
+    Details --> Location: Next (validated)
+    Location --> DateTime: Next (validated)
+    DateTime --> Spotlight: Next
+    Spotlight --> Review: Next
+    Review --> [*]: Submit
+
+    Details: Title, Organiser, Categories
+    Details: Subcategories, Tags, Description
+    Location: Street, City, Postal Code
+    Location: GPS Coordinates (optional)
+    DateTime: Single Date / Recurring / Always Open
+    Spotlight: Enable promotion + pricing
+    Review: Summary + cost breakdown
+```
+
+---
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph Page["create-event/page.tsx"]
+        STEPPER["EventFormStepper"]
+    end
+
+    subgraph FormState["React Hook Form"]
+        FORM["useForm()<br/>CreateEventFormData"]
+        ZOD["Zod Schema<br/>create-event-schema.ts"]
+    end
+
+    subgraph Steps["Step Components"]
+        S1["StepEventDetails"]
+        S2["StepEventLocation"]
+        S3["StepEventDateTime"]
+        S4["StepSpotlight"]
+        S5["StepEventReview"]
+    end
+
+    subgraph API["API Layer"]
+        PAYLOAD["createPayload()<br/>FormData → CreateEventDto"]
+        HOOK["useCreateEvent()<br/>TanStack Query mutation"]
+        AXIOS["Axios + JWT"]
+    end
+
+    STEPPER --> FORM
+    FORM --> ZOD
+    STEPPER --> S1
+    STEPPER --> S2
+    STEPPER --> S3
+    STEPPER --> S4
+    STEPPER --> S5
+
+    S5 -->|"Submit"| PAYLOAD
+    PAYLOAD --> HOOK
+    HOOK --> AXIOS
+    AXIOS -->|"POST /api/events"| BE["Backend API"]
+```
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `components/forms/EventFormStepper.tsx` | Orchestrator — manages step navigation and form state |
+| `lib/validation/create-event-schema.ts` | Zod schema + `createPayload()` + `eventDtoToFormData()` |
+| `hooks/useEventForm.ts` | Wraps `useForm()` with Zod resolver |
+| `hooks/useCreateEvent.ts` | TanStack Query mutation for POST |
+| `hooks/useEvents.ts` | `useUpdateEvent` mutation for PUT (edit mode) |
+| `components/forms/steps/Step*.tsx` | Individual step UI components |
+
+---
+
+## The 5 Steps
+
+### Step 1: Event Details (`StepEventDetails.tsx`)
+
+What the user fills in:
+- **Title** (required, max 200 chars)
+- **Organiser name** and **organisation number** (Swedish Luhn validation)
+- **Categories** (select from 8 categories)
+- **Subcategories** (3 per selected category)
+- **Filter tags** (Free, Family-friendly, Indoor, Outdoor, etc.)
+- **Description**, **image URL**, **website URL**
+
+Category selection is the most complex part — subcategories are nested under categories:
+
+```mermaid
+graph TB
+    CAT["Select Category: Sports (2)"]
+    CAT --> SUB1["201: Sports to do"]
+    CAT --> SUB2["202: Sports to watch"]
+    CAT --> SUB3["203: Sports to try"]
+```
+
+The form stores subcategories as `Record<number, number[]>` keyed by category code.
+
+### Step 2: Location (`StepEventLocation.tsx`)
+
+- **Street name** (required)
+- **City** (required)
+- **Postal code** (optional)
+- **GPS coordinates** (optional — backend can auto-geocode)
+
+### Step 3: Date & Time (`StepEventDateTime.tsx`)
+
+Three scheduling modes:
+
+```mermaid
+graph LR
+    MODE{Schedule Type}
+    MODE -->|Single| SINGLE["One date + start/end time"]
+    MODE -->|Recurring| RECURRING["Weekday + start/end time<br/>+ date range"]
+    MODE -->|Always Open| ALWAYS["No dates needed<br/>(parks, museums, etc.)"]
+```
+
+- **Single date**: Pick a date, set start and end times
+- **Recurring**: Select weekdays (0-6), set times, define a date range
+- **Always open**: Toggle — no dates needed (used for places like parks)
+
+### Step 4: Spotlight (`StepSpotlight.tsx`)
+
+Optional event promotion:
+- Enable/disable spotlight
+- Select date range for promotion
+- Pricing: 99 SEK/day + 125 SEK flat VAT
+- Cost breakdown shown in real-time
+
+### Step 5: Review (`StepEventReview.tsx`)
+
+Read-only summary of all previous steps. Shows:
+- All event details
+- Spotlight cost breakdown (if enabled)
+- Submit button that triggers `createPayload()` → API call
+
+---
+
+## Data Transformation
+
+The form state (`CreateEventFormData`) doesn't match the API format (`CreateEventDto`). The `createPayload()` function transforms it:
+
+```mermaid
+graph LR
+    A["CreateEventFormData<br/>(form state)"]
+    B["createPayload()"]
+    C["CreateEventDto<br/>(API payload)"]
+
+    A --> B --> C
+
+    subgraph Transforms
+        T1["date + startTime → ISO datetime"]
+        T2["weekday name → 0-6 index"]
+        T3["subcategories map →<br/>subcategoryCodesByCategory"]
+        T4["category selections →<br/>categoryCodes array"]
+    end
+```
+
+### Key transformations:
+
+| Form Field | API Field | Transform |
+|-----------|-----------|-----------|
+| `date` + `startTime` | `singleDate.startDate` | Combined into ISO string |
+| `"Monday"` | `recurringSchedule.dayOfWeek` | Mapped to `1` |
+| `subcategories: { 2: [201, 203] }` | `subcategoryCodesByCategory` | Passed directly |
+| Selected category toggles | `categoryCodes: [1, 2]` | Extracted from subcategory keys |
+
+### Edit Mode: Reverse Transformation
+
+When editing, `eventDtoToFormData()` converts an `EventDto` back into form state:
+
+```mermaid
+graph LR
+    A["EventDto<br/>(from API)"] --> B["eventDtoToFormData()"] --> C["CreateEventFormData<br/>(pre-filled form)"]
+```
+
+The edit page at `/my-events/[id]/edit` fetches the event, transforms it, and passes it to the same `EventFormStepper` used for creation.
+
+---
+
+## Validation
+
+Validation runs **per step** — you can't proceed to the next step without passing the current step's rules.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Step as Step Component
+    participant RHF as React Hook Form
+    participant Zod as Zod Schema
+
+    User->>Step: Click "Next"
+    Step->>RHF: trigger(currentStepFields)
+    RHF->>Zod: Validate subset of fields
+    alt Valid
+        Zod-->>RHF: No errors
+        RHF-->>Step: Proceed to next step
+    else Invalid
+        Zod-->>RHF: Field errors
+        RHF-->>Step: Display error messages
+    end
+```
+
+The Zod schema in `create-event-schema.ts` defines all validation rules:
+- Required fields (title, city, etc.)
+- String lengths (max 200 for title)
+- Swedish organisation number (Luhn algorithm)
+- Valid date ranges
+- GPS coordinate format
+
+---
+
+## Adding a New Form Field
+
+1. **Add to Zod schema** in `lib/validation/create-event-schema.ts`
+2. **Add to the Step component** that should display it
+3. **Update `createPayload()`** to include it in the API payload
+4. **Update `eventDtoToFormData()`** to populate it in edit mode
+5. **Update `types/events.ts`** if the DTO interface changes
+6. **Update `contentText.tsx`** if it's a new category/tag
+
+---
+
+## What's Next
+
+- **[Development Workflow](DEVELOPMENT-WORKFLOW.md)** — Branching, linting, and PR process
+- **[docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md)** — Full architecture with deployment diagrams

--- a/forDevelopers/GETTING-STARTED.md
+++ b/forDevelopers/GETTING-STARTED.md
@@ -1,0 +1,106 @@
+# Getting Started
+
+> From zero to a running dev server in 10 minutes.
+
+## What You're Building
+
+The GODO Frontend is the **organiser-facing website** where event organisers create, manage, and promote events. It's one part of a 3-repo platform:
+
+```mermaid
+graph LR
+    FE["Website (Next.js)<br/>(This Repo)"]
+    API[".NET 10 API"]
+    APP["Mobile App (Expo)"]
+    DB[(SQL Server)]
+
+    FE -->|"Create/manage events"| API
+    APP -->|"Browse events"| API
+    API --> DB
+```
+
+Organisers use this website. Users browse events on the mobile app. Both talk to the same backend API.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Node.js | 20+ | [nodejs.org](https://nodejs.org/) |
+| npm | 10+ | Comes with Node.js |
+| Git | 2.30+ | [git-scm.com](https://git-scm.com/) |
+| IDE | Any | VS Code recommended |
+
+**Verify Node is installed:**
+```bash
+node --version   # Should print v20.x.x or higher
+npm --version    # Should print 10.x.x or higher
+```
+
+---
+
+## Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/Go-Do-AB/Frontend.git
+cd Frontend
+```
+
+## Step 2: Install Dependencies
+
+```bash
+npm install
+```
+
+This installs Next.js, React, Tailwind, shadcn/ui, TanStack Query, and all other packages.
+
+## Step 3: Configure Environment
+
+Create a `.env.local` file in the project root:
+
+```bash
+NEXT_PUBLIC_API_URL=http://localhost:5198/api
+```
+
+This points the frontend to your local backend API. For production, this is set to `https://api.godo-dev.nu/api`.
+
+> **Note:** The backend must be running for the frontend to work. See the [Backend Getting Started](https://github.com/Go-Do-AB/Backend/blob/main/forDevelopers/GETTING-STARTED.md) guide.
+
+## Step 4: Run the Dev Server
+
+```bash
+npm run dev
+```
+
+The site opens at [http://localhost:3000](http://localhost:3000). It uses **Turbopack** for fast hot reloading.
+
+## Step 5: Verify It Works
+
+1. Open [http://localhost:3000](http://localhost:3000) — you should see the login page
+2. Log in with a seeded account:
+
+| Account | Username | Password | Role |
+|---------|----------|----------|------|
+| Admin | `martina-godo` | `martina-godo1` | Admin + Organiser |
+| Organiser | `seed.organiser` | `organiser123` | Organiser |
+
+3. After login, you should see the landing page with "Create Event" and "My Events"
+
+---
+
+## Common Issues
+
+| Problem | Solution |
+|---------|----------|
+| Login fails / network error | Make sure the backend API is running on port 5198 |
+| `NEXT_PUBLIC_API_URL` not working | Restart the dev server after changing `.env.local` |
+| npm install fails | Try deleting `node_modules` and `package-lock.json`, then `npm install` |
+| Port 3000 in use | Kill the process or use `npm run dev -- -p 3001` |
+
+---
+
+## What's Next
+
+1. **[Project Walkthrough](PROJECT-WALKTHROUGH.md)** — Understand the folder structure and key files
+2. **[Form Guide](FORM-GUIDE.md)** — How the multi-step event creation form works
+3. **[Development Workflow](DEVELOPMENT-WORKFLOW.md)** — Branch strategy and PR process

--- a/forDevelopers/PROJECT-WALKTHROUGH.md
+++ b/forDevelopers/PROJECT-WALKTHROUGH.md
@@ -1,0 +1,230 @@
+# Project Walkthrough
+
+> A visual tour of the codebase — what each folder does and how they connect.
+
+## High-Level Architecture
+
+```mermaid
+graph TB
+    subgraph Browser["Browser"]
+        PAGES["App Router Pages"]
+        COMPONENTS["React Components"]
+        HOOKS["TanStack Query Hooks"]
+        FORMS["React Hook Form + Zod"]
+    end
+
+    subgraph Transport["Transport Layer"]
+        AXIOS["Axios Instance<br/>+ JWT Interceptor"]
+    end
+
+    subgraph Backend["Backend API (.NET 10)"]
+        API["REST Endpoints"]
+        DB[(SQL Server)]
+    end
+
+    PAGES --> COMPONENTS
+    PAGES --> HOOKS
+    PAGES --> FORMS
+    HOOKS --> AXIOS
+    FORMS -->|"createPayload()"| AXIOS
+    AXIOS -->|"Authorization: Bearer ..."| API
+    API --> DB
+```
+
+---
+
+## Folder Structure
+
+```
+Frontend/
+├── src/
+│   ├── app/                          # Next.js App Router (pages)
+│   │   ├── layout.tsx                # Root layout (providers, navbar, fonts)
+│   │   ├── page.tsx                  # "/" → redirects to /login
+│   │   ├── (auth)/                   # Auth route group (no layout nesting)
+│   │   │   ├── login/page.tsx        # Organiser login form
+│   │   │   ├── register/page.tsx     # Organiser registration form
+│   │   │   └── forgot-password/      # Forgot password (placeholder)
+│   │   ├── landing/page.tsx          # Main hub after login (role-based UI)
+│   │   ├── create-event/page.tsx     # Multi-step event creation form
+│   │   ├── my-events/
+│   │   │   ├── page.tsx              # Organiser's event dashboard
+│   │   │   └── [id]/edit/page.tsx    # Edit existing event
+│   │   ├── quick-create/page.tsx     # Admin-only simplified event creation
+│   │   └── preview/page.tsx          # Mobile app preview mockup
+│   │
+│   ├── components/
+│   │   ├── global/
+│   │   │   └── Navbar.tsx            # Top navigation bar (logo, search, logout)
+│   │   ├── forms/
+│   │   │   ├── EventFormStepper.tsx  # Multi-step form orchestrator (the big one)
+│   │   │   ├── QuickCreateForm.tsx   # Simplified admin form
+│   │   │   ├── TimePicker.tsx        # Custom time selector
+│   │   │   └── steps/               # Individual form steps
+│   │   │       ├── StepEventDetails.tsx    # Step 1: Title, org, categories
+│   │   │       ├── StepEventLocation.tsx   # Step 2: Address, GPS
+│   │   │       ├── StepEventDateTime.tsx   # Step 3: Dates and times
+│   │   │       ├── StepSpotlight.tsx       # Step 4: Promotion pricing
+│   │   │       └── StepEventReview.tsx     # Step 5: Review and submit
+│   │   ├── events/
+│   │   │   └── EventTicketCard.tsx   # Success card after event creation
+│   │   ├── preview/                  # Mobile app mockup components
+│   │   └── ui/                       # shadcn/ui components (button, card, dialog, etc.)
+│   │
+│   ├── hooks/
+│   │   ├── useEvents.ts             # CRUD hooks: useEvents, useEvent, useUpdateEvent, etc.
+│   │   ├── useCreateEvent.ts        # Create event mutation
+│   │   ├── useQuickCreateEvent.ts   # Quick-create mutation
+│   │   └── useEventForm.ts          # Form hook with Zod resolver
+│   │
+│   ├── lib/
+│   │   ├── axios.ts                 # Shared Axios instance + JWT interceptor
+│   │   ├── utils.ts                 # Helpers (date formatting, org nr validation, cn())
+│   │   ├── content/
+│   │   │   └── contentText.tsx      # Category/subcategory/tag definitions (must match backend)
+│   │   └── validation/
+│   │       ├── create-event-schema.ts    # Zod schema + createPayload() + eventDtoToFormData()
+│   │       └── quick-create-schema.ts    # Quick-create Zod schema
+│   │
+│   ├── providers/
+│   │   └── react-query-provider.tsx  # TanStack Query provider setup
+│   │
+│   └── types/
+│       └── events.ts                # TypeScript interfaces (matches backend DTOs exactly)
+│
+├── public/                          # Static assets (images, icons)
+├── Dockerfile                       # Multi-stage Docker build for production
+├── next.config.ts                   # Next.js config (standalone output)
+├── tailwind.config.ts               # Tailwind CSS config
+├── package.json                     # Dependencies and scripts
+└── docs/                            # Reference documentation
+```
+
+---
+
+## Key Files Deep-Dive
+
+### Pages (App Router)
+
+```mermaid
+graph TB
+    ROOT["/"] -->|redirect| LOGIN["/login"]
+    LOGIN -->|auth| LANDING["/landing"]
+    LANDING --> CREATE["/create-event"]
+    LANDING --> MY["/my-events"]
+    LANDING --> QUICK["/quick-create<br/>(Admin only)"]
+    LANDING --> PREVIEW["/preview"]
+    MY --> EDIT["/my-events/[id]/edit"]
+```
+
+Each page is a `page.tsx` file inside `src/app/`. The App Router handles routing automatically based on the folder structure.
+
+### The Form System
+
+The event form is the most complex part of the frontend:
+
+```mermaid
+graph TB
+    STEPPER["EventFormStepper.tsx<br/>(orchestrator)"]
+    SCHEMA["create-event-schema.ts<br/>(Zod validation)"]
+    HOOK["useEventForm.ts<br/>(React Hook Form + Zod)"]
+
+    STEPPER --> HOOK
+    HOOK --> SCHEMA
+
+    STEPPER --> S1["StepEventDetails"]
+    STEPPER --> S2["StepEventLocation"]
+    STEPPER --> S3["StepEventDateTime"]
+    STEPPER --> S4["StepSpotlight"]
+    STEPPER --> S5["StepEventReview"]
+
+    S5 -->|"createPayload()"| API["POST /api/events"]
+```
+
+- **`EventFormStepper.tsx`** — Controls step navigation, holds form state
+- **`create-event-schema.ts`** — Zod schema for validation + `createPayload()` to transform form data to API format
+- **Each Step component** — Renders its portion of the form, uses `useFormContext()` to access shared form state
+
+### Data Layer
+
+```mermaid
+graph LR
+    subgraph Hooks["Custom Hooks"]
+        UE["useEvents()"]
+        UCE["useCreateEvent()"]
+        UUE["useUpdateEvent()"]
+        UDE["useDeleteEvent()"]
+    end
+
+    subgraph Core["Shared Infrastructure"]
+        AX["axios.ts<br/>(JWT interceptor)"]
+        TYPES["types/events.ts<br/>(TypeScript interfaces)"]
+    end
+
+    UE --> AX
+    UCE --> AX
+    UUE --> AX
+    UDE --> AX
+    UE --> TYPES
+```
+
+- **`axios.ts`** — Single Axios instance with JWT interceptor that reads `accessToken` from localStorage
+- **`types/events.ts`** — TypeScript interfaces matching the backend DTOs exactly
+- **Hooks** — Wrap TanStack Query's `useQuery`/`useMutation` for type-safe API calls
+
+### Content Definitions
+
+**`contentText.tsx`** contains the category, subcategory, and tag definitions. These **must match the backend's DataSeeder exactly**.
+
+| What | Codes | Example |
+|------|-------|---------|
+| Categories | 1-8 | Sports (2) |
+| Subcategories | catCode*100 + index | Sports to do (201) |
+| Tags | 1001-1006 | Free (1001) |
+
+---
+
+## How Everything Connects
+
+```mermaid
+sequenceDiagram
+    participant Page as Page Component
+    participant Form as React Hook Form
+    participant Zod as Zod Validator
+    participant Hook as TanStack Query Hook
+    participant Axios as Axios + JWT
+    participant API as Backend API
+
+    Page->>Form: useForm() with Zod resolver
+    Form->>Zod: Validate on submit
+    alt Validation passes
+        Form->>Hook: mutate(createPayload(formData))
+        Hook->>Axios: POST /api/events
+        Axios->>Axios: Add Authorization header
+        Axios->>API: Request with JWT
+        API-->>Hook: OperationResult<EventDto>
+        Hook-->>Page: onSuccess callback
+    else Validation fails
+        Zod-->>Form: Error messages
+        Form-->>Page: Display field errors
+    end
+```
+
+---
+
+## Key Files to Read First
+
+| # | File | Why |
+|---|------|-----|
+| 1 | `src/app/layout.tsx` | Root layout — providers, navbar, global setup |
+| 2 | `src/lib/axios.ts` | How all API calls are made, JWT handling |
+| 3 | `src/components/forms/EventFormStepper.tsx` | The core form — most complex component |
+| 4 | `src/lib/validation/create-event-schema.ts` | Form validation + API payload transformation |
+| 5 | `src/hooks/useEvents.ts` | How data fetching works with TanStack Query |
+
+---
+
+## What's Next
+
+- **[Form Guide](FORM-GUIDE.md)** — Deep-dive into the multi-step event form
+- **[Development Workflow](DEVELOPMENT-WORKFLOW.md)** — How to make changes, lint, and submit PRs

--- a/forDevelopers/README.md
+++ b/forDevelopers/README.md
@@ -1,0 +1,45 @@
+# Developer Guides
+
+> Hands-on guides for developers working on the GODO Frontend (Website).
+
+## What's Here
+
+These guides are written for developers who are **new to the project** or need a refresher. They focus on *how to work* in this codebase — not just what exists.
+
+| Guide | What You'll Learn | Time |
+|-------|-------------------|------|
+| [Getting Started](GETTING-STARTED.md) | Clone, install, run the dev server | 10 min |
+| [Project Walkthrough](PROJECT-WALKTHROUGH.md) | Visual tour of every folder and key file | 20 min |
+| [Form Guide](FORM-GUIDE.md) | How the multi-step event form works | 20 min |
+| [Development Workflow](DEVELOPMENT-WORKFLOW.md) | Branching, linting, CI/CD, PR checklist | 15 min |
+
+## Recommended Reading Order
+
+```mermaid
+graph LR
+    A["1. Getting Started"] --> B["2. Project Walkthrough"]
+    B --> C["3. Form Guide"]
+    C --> D["4. Development Workflow"]
+
+    style A fill:#F3C10E,color:#000
+    style B fill:#F3C10E,color:#000
+    style C fill:#F3C10E,color:#000
+    style D fill:#F3C10E,color:#000
+```
+
+**First day?** Start with Getting Started, then Project Walkthrough.
+**Ready to code?** Read Form Guide, then Development Workflow.
+
+## How This Relates to `docs/`
+
+| Folder | Purpose |
+|--------|---------|
+| `forDevelopers/` | How-to guides, tutorials, onboarding |
+| `docs/` | Reference documentation (architecture, API integration, deployment) |
+
+## Other Repos
+
+| Repo | Description | Developer Guides |
+|------|-------------|------------------|
+| [Backend (.NET 10)](https://github.com/Go-Do-AB/Backend) | API server | `forDevelopers/` in that repo |
+| [Mobile App (Expo)](https://github.com/Go-Do-AB/MobileApp) | iOS/Android app for end users | `forDevelopers/` in that repo |


### PR DESCRIPTION
## Summary
- Rewrite root `README.md` with platform overview, Mermaid diagrams, quick start, tech stack, and CI/CD pipeline
- Create `forDevelopers/` folder with 5 guides: README, Getting Started, Project Walkthrough, Form Guide, Development Workflow
- Create `docs/README.md` (documentation hub) and `docs/ONBOARDING.md` (15-min orientation)
- Correct platform identity: GODO is a **multi-city platform**, not Helsingborg-specific
- Existing `docs/ARCHITECTURE.md` unchanged — just properly linked

**8 files, ~1,200 lines of documentation**

## Test plan
- [ ] Verify all Mermaid diagrams render on GitHub
- [ ] Verify all internal links resolve correctly
- [ ] No "for Helsingborg" platform identity framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)