### PR TITLE
Fix PR checks: lint blocks PR, add type check and security audit

### DIFF
--- a/.github/workflows/pull-request-check-action.yml
+++ b/.github/workflows/pull-request-check-action.yml
@@ -1,36 +1,43 @@
-name: Pull Request Action Check
+name: PR Checks (Frontend)
 
-# 📌 This workflow runs automatically when someone opens a Pull Request to "development"
 on:
   pull_request:
     branches: [main]
 
 jobs:
   build-and-check:
-    name: Pull Request Action Check
-    runs-on: ubuntu-latest # 🖥️ Use the latest Ubuntu runner provided by GitHub
+    name: Build, Lint & Type Check
+    runs-on: ubuntu-latest
 
     steps:
-      - name: 📥 Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v4
-        # 👉 This pulls the repo's code into the GitHub Actions machine
 
-      - name: 🟢 Setup Node.js
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-        # 👉 Makes sure Node.js v20 is installed (required for Next.js 16+)
 
-      - name: 📦 Install dependencies
-        run: npm install
-        # 👉 Installs everything from package.json
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
 
-      - name: 🏗️ Build Next.js app
-        run: npm run build
-        # 👉 Runs the Next.js build (fails PR if it doesn’t compile)
+      - name: Install dependencies
+        run: npm ci
 
-      - name: ✨ Lint code
+      - name: Lint code
         run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build
+
+      - name: Security audit
+        run: npm audit --audit-level=high
         continue-on-error: true
-        # 👉 Optional: checks code style with ESLint
-        # "continue-on-error: true" means it won’t fail the PR, just warn

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 |----------|----------------|
 | [ARCHITECTURE.md](ARCHITECTURE.md) | System design — tech stack, data flow, deployment, form architecture |
 | [ONBOARDING.md](ONBOARDING.md) | 15-minute orientation for new team members |
+| [CI/CD & Deployment](https://github.com/Go-Do-AB/Backend/blob/main/docs/CI-CD-DEPLOYMENT.md) | Visual CI/CD pipeline & deploy flow (both BE + FE) — lives in Backend repo |
 
 ## Developer Guides
 


### PR DESCRIPTION
## Summary
- **Lint now blocks PRs** — removed `continue-on-error: true` (was silently ignoring lint failures)
- **Added TypeScript type check** — `npx tsc --noEmit` catches type errors before merge
- **Use `npm ci`** instead of `npm install` — deterministic installs from lockfile
- **Added `npm audit`** — warns about known CVEs in dependencies (non-blocking)
- **Added npm cache** — faster CI runs
- Link to shared CI/CD deployment guide in `docs/README.md`

## Test plan
- [ ] Verify lint step now blocks PR on failure
- [ ] Verify tsc type check runs and blocks on errors
- [ ] Verify npm audit runs but doesn't block

🤖 Generated with [Claude Code](https://claude.com/claude-code)