### PR TITLE
feat: align preview with Expo app design system

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -136,3 +136,9 @@
   50% { background-position: 100% 50%; }
   100% { background-position: 0% 50%; }
 }
+
+/* Subcategory expand animation for preview */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -44,7 +44,7 @@ export default function PreviewPage() {
           <div className="grid grid-cols-2 gap-4 mb-8">
             <Feature
               icon={<Layers size={20} />}
-              title="7 Kategorier"
+              title="8 Kategorier"
               desc="Från sport till kultur"
             />
             <Feature

--- a/src/components/preview/AppPreview.tsx
+++ b/src/components/preview/AppPreview.tsx
@@ -18,8 +18,25 @@ export function AppPreview() {
     selectedCategories: [],
   });
 
+  // Shared filter state (persists across screens like the Expo app's FilterContext)
+  const [searchText, setSearchText] = useState("");
+  const [cities, setCities] = useState<string[]>([]);
+  const [startDate, setStartDate] = useState<string | null>(null);
+  const [endDate, setEndDate] = useState<string | null>(null);
+
   const handleTagsChange = (newTagCodes: number[]) => {
     setScreen((prev) => ({ ...prev, tagCodes: newTagCodes }));
+  };
+
+  const handleToggleCity = (city: string) => {
+    setCities((prev) =>
+      prev.includes(city) ? prev.filter((c) => c !== city) : [...prev, city],
+    );
+  };
+
+  const handleDateRange = (start: string | null, end: string | null) => {
+    setStartDate(start);
+    setEndDate(end);
   };
 
   return (
@@ -28,6 +45,14 @@ export function AppPreview() {
         <HomeScreen
           tagCodes={screen.tagCodes}
           selectedCategories={screen.selectedCategories}
+          searchText={searchText}
+          cities={cities}
+          startDate={startDate}
+          endDate={endDate}
+          onSearchChange={setSearchText}
+          onToggleCity={handleToggleCity}
+          onSetCities={setCities}
+          onDateRange={handleDateRange}
           onTagsChange={handleTagsChange}
           onToggleCategory={(code) => {
             setScreen((prev) => {
@@ -62,6 +87,10 @@ export function AppPreview() {
           categoryCode={screen.categoryCode}
           tagCodes={screen.tagCodes}
           showMap={screen.showMap}
+          searchText={searchText}
+          cities={cities}
+          startDate={startDate}
+          endDate={endDate}
           onToggleMap={() =>
             setScreen((prev) =>
               prev.type === "results" ? { ...prev, showMap: !prev.showMap } : prev,

--- a/src/components/preview/constants.ts
+++ b/src/components/preview/constants.ts
@@ -1,34 +1,144 @@
-// Mobile app design tokens — matches the Go.Do Expo app accessibility-redesign
+/**
+ * Preview design tokens — mirrors Expo app theme.ts exactly.
+ *
+ * Source of truth: MobileApp/constants/theme.ts
+ * Font: Calibri-Bold for branding, system-ui for body text
+ */
 
-// ── Brand palette ─────────────────────────────────────────────────
-export const BRAND = {
-  yellow: "#F3C10E",
-  yellowLight: "#FFF9D6",
-  yellowDark: "#D4A80C",
-  onPrimary: "#2A2000",
-  background: "#FAF8F3",
-  surface: "#FFFEFA",
-  textPrimary: "#1C1C1E",
-  textBody: "#3C3C43",
-  textSecondary: "#8E8E93",
-  border: "#E8E5DD",
-  neutral100: "#F5F2EB",
-  neutral200: "#E8E5DD",
-  neutral300: "#D1CEC6",
+// ── Go.Do Yellow ramp (matches GodoYellow in theme.ts) ──────────────
+export const GodoYellow = {
+  50: "#FFFDF0",
+  100: "#FFF9D6",
+  200: "#FFF2AD",
+  300: "#FFEA85",
+  400: "#F7D84E",
+  500: "#F3C10E", // Main brand
+  600: "#D4A80C",
+  700: "#B88C08",
+  800: "#8A6906",
+  900: "#5C4604",
 } as const;
 
-// ── Category dark colors (AAA contrast on white) ─────────────────
+// ── Neutrals: warm grays (matches Neutral in theme.ts) ──────────────
+export const Neutral = {
+  0: "#FFFFFF",
+  50: "#FAF8F3",   // Background (list areas)
+  100: "#F5F2EB",
+  200: "#E8E5DD",
+  300: "#D1CEC6",
+  400: "#AEABA3",
+  500: "#8E8E93",  // Meta text
+  600: "#6C6C70",
+  700: "#3C3C43",  // Body text
+  800: "#1C1C1E",  // Heading text
+  900: "#0A0A0A",
+} as const;
+
+// ── Core surfaces (matches Surface in theme.ts) ─────────────────────
+export const Surface = {
+  background: "#F2C10E",  // Go.Do brand yellow
+  surface: "#FFFEFA",     // Soft white
+  elevated: "#FFFFFF",    // Pure white (cards with shadow)
+  onPrimary: "#2A2000",   // Dark brown text on yellow
+} as const;
+
+// ── Typography (matches Typography in theme.ts) ─────────────────────
+export const Typography = {
+  hero:         { size: 28, weight: 700, lineHeight: 34 },
+  sectionTitle: { size: 20, weight: 600, lineHeight: 26 },
+  cardTitle:    { size: 16, weight: 600, lineHeight: 22 },
+  body:         { size: 15, weight: 400, lineHeight: 22 },
+  meta:         { size: 13, weight: 400, lineHeight: 18 },
+  caption:      { size: 12, weight: 400, lineHeight: 16 },
+  button:       { size: 16, weight: 600, lineHeight: 22 },
+} as const;
+
+// ── Font families ───────────────────────────────────────────────────
+// Expo app uses Calibri-Bold for Go.Do branding, system font elsewhere
+export const FontFamily = {
+  brand: "'Calibri', 'Carlito', sans-serif",   // Go.Do logo + branded buttons
+  body: "system-ui, -apple-system, sans-serif", // All body text
+} as const;
+
+// ── Spacing: 8pt grid (matches Spacing in theme.ts) ─────────────────
+export const Spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32,
+  "2xl": 40,
+  screenPadding: 20,
+} as const;
+
+// ── Border radii (matches Radii in theme.ts) ────────────────────────
+export const Radii = {
+  sm: 8,
+  input: 12,
+  card: 18,
+  sheet: 24,
+  button: 26,
+  pill: 999,
+} as const;
+
+// ── CSS shadows (adapted from RN Shadows in theme.ts) ───────────────
+export const Shadows = {
+  sm: "0 1px 3px rgba(0,0,0,0.04)",
+  md: "0 2px 8px rgba(0,0,0,0.06)",
+  lg: "0 4px 16px rgba(0,0,0,0.08)",
+} as const;
+
+// ── CoolPastels (for event card styling) ────────────────────────────
+export const CoolPastels = {
+  secondary50: "#F4F0F9",   // Card background
+  secondary100: "#E9E1F3",  // Card border
+  neutral50: "#F8FAFC",
+  neutral300: "#CBD5E1",
+  neutral400: "#94A3B8",
+  neutral800: "#1F2937",
+} as const;
+
+// ── Legacy BRAND alias (backwards-compatible) ───────────────────────
+// Components reference BRAND.* — maps to proper tokens above
+export const BRAND = {
+  yellow: GodoYellow[500],
+  yellowLight: GodoYellow[100],
+  yellowDark: GodoYellow[600],
+  yellow50: GodoYellow[50],
+  yellow200: GodoYellow[200],
+  yellow300: GodoYellow[300],
+  onPrimary: Surface.onPrimary,
+  background: Surface.background,
+  surface: Surface.surface,
+  elevated: Surface.elevated,
+  textPrimary: Neutral[800],
+  textBody: Neutral[700],
+  textSecondary: Neutral[500],
+  border: Neutral[200],
+  neutral50: Neutral[50],
+  neutral100: Neutral[100],
+  neutral200: Neutral[200],
+  neutral300: Neutral[300],
+  neutral400: Neutral[400],
+  neutral500: Neutral[500],
+  neutral600: Neutral[600],
+  neutral800: Neutral[800],
+  neutral900: Neutral[900],
+} as const;
+
+// ── Category dark colors (matches CategoryDark in theme.ts) ─────────
 export const CATEGORY_COLORS: Record<number, string> = {
-  1: "#991B1B", // Events — red
-  2: "#581C87", // Sports — purple
-  3: "#1E3A5F", // Entertainment — navy
-  4: "#1E3A8A", // Culture — blue
-  5: "#374151", // Adventure — gray
-  6: "#7C2D12", // Learn — orange
-  7: "#9D174D", // Health — pink
+  1: "#FF0000", // Events — Red
+  2: "#7030A0", // Sports — Purple
+  3: "#000000", // Entertainment — Black
+  4: "#3333CC", // Culture — Blue
+  5: "#7F7F7F", // Adventure — Gray
+  6: "#ED7D31", // Learn — Orange
+  7: "#FF3399", // Health — Pink
+  8: "#00B050", // Fun for Kids — Green
 };
 
-// ── Category tints (soft pastels for tile backgrounds) ────────────
+// ── Category tints (matches CategoryTints in theme.ts) ──────────────
 export const CATEGORY_TINTS: Record<number, string> = {
   1: "#FEF2F2",
   2: "#F5F3FF",
@@ -37,9 +147,10 @@ export const CATEGORY_TINTS: Record<number, string> = {
   5: "#F5F5F4",
   6: "#FFF7ED",
   7: "#FDF2F8",
+  8: "#E8F8E8",
 };
 
-// ── Gradient pairs for hero sections ──────────────────────────────
+// ── Gradient pairs for hero sections ────────────────────────────────
 export const CATEGORY_GRADIENTS: Record<number, [string, string]> = {
   1: ["#FCA5A5", "#F87171"],
   2: ["#C4B5FD", "#A78BFA"],
@@ -48,9 +159,10 @@ export const CATEGORY_GRADIENTS: Record<number, [string, string]> = {
   5: ["#A8A29E", "#78716C"],
   6: ["#FDBA74", "#FB923C"],
   7: ["#F9A8D4", "#F472B6"],
+  8: ["#86EFAC", "#4ADE80"],
 };
 
-// ── Short labels (Swedish) ────────────────────────────────────────
+// ── Short labels (Swedish) ──────────────────────────────────────────
 export const CATEGORY_SHORT_LABELS: Record<number, string> = {
   1: "Evenemang",
   2: "Idrott",
@@ -59,9 +171,10 @@ export const CATEGORY_SHORT_LABELS: Record<number, string> = {
   5: "Upplevelser",
   6: "Utforska",
   7: "Hälsa",
+  8: "Kul för barn",
 };
 
-// ── Category icons for the map pins ───────────────────────────────
+// ── Category icons for the map pins ─────────────────────────────────
 export const CATEGORY_EMOJIS: Record<number, string> = {
   1: "🎉",
   2: "⚽",
@@ -70,12 +183,16 @@ export const CATEGORY_EMOJIS: Record<number, string> = {
   5: "🏔️",
   6: "📚",
   7: "🧘",
+  8: "🧒",
 };
 
-// ── GPS coordinates for mock events (Helsingborg area) ────────────
+// ── GPS coordinates for mock events ─────────────────────────────────
 export const HELSINGBORG_CENTER = { lat: 56.0465, lng: 12.6945 };
 export const MOCK_LOCATIONS: Record<string, { lat: number; lng: number }> = {
   Helsingborg: { lat: 56.0465, lng: 12.6945 },
   "Malmö": { lat: 55.6050, lng: 13.0038 },
   Lund: { lat: 55.7047, lng: 13.1910 },
+  Landskrona: { lat: 55.8708, lng: 12.8301 },
+  "Ängelholm": { lat: 56.2428, lng: 12.8622 },
+  "Höganäs": { lat: 56.1996, lng: 12.5574 },
 };

--- a/src/components/preview/mockEvents.ts
+++ b/src/components/preview/mockEvents.ts
@@ -5,8 +5,9 @@
  * Swedish events from the Helsingborg/Nordvästra Skåne region.
  *
  * Coverage:
- *  - 7 categories × 3 subcategories × 3 events = 63 events
- *  - Every tag (1001-1006) appears on at least 5 events
+ *  - 8 categories × 3 subcategories × ~5 events = ~120+ events
+ *  - 6 cities, each with 10+ events
+ *  - Every tag (1001-1006) appears on many events
  *  - Authentic Swedish titles, descriptions, locations, and organizers
  */
 
@@ -24,6 +25,7 @@ const CATS: Record<number, { name: string; nameSv: string }> = {
   5: { name: "Upplevelser & äventyr", nameSv: "Upplevelser & äventyr" },
   6: { name: "Lära & utforska", nameSv: "Lära & utforska" },
   7: { name: "Hälsa & välmående", nameSv: "Hälsa & välmående" },
+  8: { name: "Kul för barn", nameSv: "Kul för barn" },
 };
 
 const SUBS: Record<number, { name: string; nameSv: string }> = {
@@ -48,6 +50,9 @@ const SUBS: Record<number, { name: string; nameSv: string }> = {
   701: { name: "Spa & bad", nameSv: "Spa & bad" },
   702: { name: "Stöd & samverkan", nameSv: "Stöd & samverkan" },
   703: { name: "Trosaktiviteter", nameSv: "Trosaktiviteter" },
+  801: { name: "0–4 år", nameSv: "0–4 år" },
+  802: { name: "5–10 år", nameSv: "5–10 år" },
+  803: { name: "11–15 år", nameSv: "11–15 år" },
 };
 
 const TAGS: Record<number, string> = {
@@ -103,321 +108,234 @@ function evt(
 }
 
 // ────────────────────────────────────────────────────────────────
-// 63 mock events — realistic Helsingborg/NV Skåne events
-// Tags are distributed so each of the 6 tags covers ≥ 5 events
+// 130+ mock events — realistic Skåne events across 6 cities
+// Each category: 10+ events | Each city: 10+ events
 // ────────────────────────────────────────────────────────────────
 
 export const MOCK_EVENTS: EventDto[] = [
-  // ── Kategori 1: Evenemang ────────────────────────────────────
+  // ══════════════════════════════════════════════════════════════
+  // Kategori 8: Kul för barn (Kids first — family-friendly order)
+  // ══════════════════════════════════════════════════════════════
+
+  // 801 — 0–4 år
+  evt(8, 801, "Babyrytmik på Familjecentralen", "Sång, musik och rörelse för de allra minsta. Barnmorska finns på plats. Gratis drop-in för barn 0–2 år med förälder.", "Familjecentralen Helsingborg", "Drottninggatan 14", "Helsingborg", "25221", 2, [1001, 1003, 1002, 1006]),
+  evt(8, 801, "Sagostund på Stadsbiblioteket", "Bibliotekarien läser sagor och sjunger sånger för barn 1–3 år. Gratis, ingen anmälan krävs. Mjuka mattor och kuddar.", "Stadsbiblioteket Helsingborg", "Bollbrogatan 1", "Helsingborg", "25220", 5, [1001, 1003, 1002]),
+  evt(8, 801, "Småbarnsdisco på Kulturhuset", "Dansa, lek och bubbelbad av musik för de yngsta! Anpassat för barn 0–4 år. Fika till föräldrarna.", "Malmö Kulturhus", "Södergatan 8", "Malmö", "21134", 3, [1003, 1002]),
+  evt(8, 801, "Kryp & kläng på lekplatsen", "Organiserad utomhuslek för småbarn med pedagoger. Hinderbana, sandlåda och vattenlek. Gratis, drop-in.", "Lunds kommun", "Stadsparken", "Lund", "22100", 7, [1001, 1004, 1002]),
+
+  // 802 — 5–10 år
+  evt(8, 802, "Barnens dag på Fredriksdal", "Ansiktsmålning, trollerishow, ponnyriding och glasstånd. Hela dagen med aktiviteter för barn 5–10 år.", "Fredriksdals museer", "Gisela Trapps väg 1", "Helsingborg", "25431", 4, [1004, 1002]),
+  evt(8, 802, "Lego-byggverkstad", "Bygg fritt med tusentals legobitar! Tävling om bästa bygge med priser. Alla barn 5–12 år välkomna.", "Landskrona Kulturhus", "Kasernplan 1", "Landskrona", "26131", 6, [1003, 1002, 1001]),
+  evt(8, 802, "Cirkusskola för barn", "Lär dig jonglera, balansera och göra akrobatik. Professionella cirkusartister leder workshopen. Ingen erfarenhet krävs.", "Cirkus Helsingborg", "Sundstorget 1", "Helsingborg", "25221", 8, [1003, 1002]),
+  evt(8, 802, "Barnteater: Trollskogen", "En magisk föreställning om djuren i skogen. Sång, dans och interaktion med publiken. För barn 4–9 år.", "Malmö Stadsteater", "Östra Rönneholmsvägen 20", "Malmö", "21147", 10, [1003, 1002]),
+  evt(8, 802, "Skattjakt i stadsparken", "Följ ledtrådar och hitta skatten! Organiserad skattjakt med priser. Gratis deltagande, samling vid entrén.", "Ängelholms kommun", "Hembygdsparken", "Ängelholm", "26235", 12, [1001, 1004, 1002]),
+
+  // 803 — 11–15 år
+  evt(8, 803, "Ungdomskodkväll", "Lär dig programmera spel med Scratch och Python. Datorer finns på plats. Gratis för 11–15-åringar.", "Mindpark Helsingborg", "Bredgatan 11", "Helsingborg", "25225", 3, [1001, 1003]),
+  evt(8, 803, "Graffiti-workshop för unga", "Lär dig streetart-teknik med professionella konstnärer. Allt material ingår. Kläder som tål färg rekommenderas.", "Höganäs Kulturskola", "Långarödsvägen 4", "Höganäs", "26332", 9, [1004, 1002]),
+  evt(8, 803, "Ungdomsfilmfestival", "Visa din egen kortfilm eller titta på andras! Filmtävling för 12–18-åringar med jury och priser.", "Dunkers kulturhus", "Kungsgatan 11", "Helsingborg", "25221", 14, [1003]),
+  evt(8, 803, "Skateboard-klinik", "Prova skateboard med instruktörer från lokala skateföreningen. Hjälm och skydd finns att låna.", "Landskrona Skatepark", "Rådmansgatan 10", "Landskrona", "26131", 16, [1004, 1001]),
+  evt(8, 803, "E-sport-turnering för ungdomar", "Tävla i populära spel med vänner! Datorer och konsoler finns. Fikabuffé ingår.", "Lunds ungdomshus", "Kiliansgatan 9", "Lund", "22100", 19, [1003, 1002]),
+
+  // ══════════════════════════════════════════════════════════════
+  // Kategori 1: Evenemang
+  // ══════════════════════════════════════════════════════════════
+
   // 101 Festivaler & skoj
-  evt(1, 101,
-    "Sommarfestival på Sundstorget",
-    "Helsingborgs stora sommarfestival med livemusik, street food och aktiviteter för hela familjen. Lokala artister och mat från regionens bästa restauranger.",
-    "Helsingborgs stad", "Sundstorget", "Helsingborg", "25221", 5, [1001, 1004, 1002]),
-  evt(1, 101,
-    "Helsingborgs Kulturnatt",
-    "En kväll fylld av kultur, konst och musik på platser runt om i staden. Museer, gallerier och scener håller öppet till midnatt.",
-    "Helsingborgs stad", "Stortorget 17", "Helsingborg", "25221", 12, [1001, 1004, 1006]),
-  evt(1, 101,
-    "Skånsk matfestival",
-    "Upplev det bästa av skånsk matkultur med provsmakningar, matlagningsdemonstrationer och lokala producenter. Tre dagar av gastronomiska upplevelser.",
-    "Region Skåne", "Kungstorget 1", "Helsingborg", "25221", 18, [1004, 1002]),
+  evt(1, 101, "Sommarfestival på Sundstorget", "Helsingborgs stora sommarfestival med livemusik, street food och aktiviteter för hela familjen.", "Helsingborgs stad", "Sundstorget", "Helsingborg", "25221", 5, [1001, 1004, 1002]),
+  evt(1, 101, "Helsingborgs Kulturnatt", "En kväll fylld av kultur, konst och musik på platser runt om i staden. Museer och scener håller öppet till midnatt.", "Helsingborgs stad", "Stortorget 17", "Helsingborg", "25221", 12, [1001, 1004, 1006]),
+  evt(1, 101, "Malmöfestivalen", "Skandinaviens största stadsfestival med musik, mat och kultur i åtta dagar. Gratis entré till alla scener.", "Malmö stad", "Gustav Adolfs torg", "Malmö", "21139", 18, [1001, 1004, 1002]),
+  evt(1, 101, "Midsommarfirande i Höganäs", "Traditionellt midsommarfirande med dans kring stången, sill och jordgubbar. Levande folkmusik hela dagen.", "Höganäs kommun", "Kvickbadet", "Höganäs", "26339", 22, [1001, 1004, 1002]),
 
   // 102 Fritid & livsstil
-  evt(1, 102,
-    "Hälsomässan Helsingborg",
-    "Sveriges ledande hälsomässa med föreläsningar, provträning och utställare inom hälsa, kost och välmående. Fri entré för alla besökare.",
-    "Helsingborg Arena", "Mellersta Stenbocksgatan 16", "Helsingborg", "25437", 3, [1001, 1003, 1006]),
-  evt(1, 102,
-    "Loppmarknad på Fredriksdal",
-    "Stor loppmarknad i den vackra miljön på Fredriksdals friluftsmuseum. Hundratals säljare med allt från antikt till vintage.",
-    "Fredriksdals museer och trädgårdar", "Gisela Trapps väg 1", "Helsingborg", "25431", 7, [1004]),
-  evt(1, 102,
-    "Trädgårdsdagen på Sofiero",
-    "Inspiration för alla trädgårdsentusiaster med workshops, försäljning av växter och guidade turer i Sofieros berömda rhododendronpark.",
-    "Sofiero Slott", "Sofiero Slottsväg 131", "Helsingborg", "25489", 14, [1004, 1005]),
+  evt(1, 102, "Hälsomässan Helsingborg", "Sveriges ledande hälsomässa med föreläsningar, provträning och utställare. Fri entré.", "Helsingborg Arena", "Mellersta Stenbocksgatan 16", "Helsingborg", "25437", 3, [1001, 1003, 1006]),
+  evt(1, 102, "Loppmarknad på Fredriksdal", "Stor loppmarknad i den vackra miljön på Fredriksdals friluftsmuseum. Hundratals säljare.", "Fredriksdals museer", "Gisela Trapps väg 1", "Helsingborg", "25431", 7, [1004]),
+  evt(1, 102, "Trädgårdsmässa i Lund", "Inspiration för trädgårdsentusiaster med workshops, växtförsäljning och föreläsningar om hållbar odling.", "Lunds kommun", "Botaniska trädgården", "Lund", "22100", 14, [1004, 1005]),
+  evt(1, 102, "Vintagemässan Malmö", "Kläder, möbler och kuriosa från 50-tal till 90-tal. Över 80 utställare under ett tak.", "Malmö Live", "Dag Hammarskjölds torg 4", "Malmö", "21118", 20, [1003]),
 
   // 103 Mässor & marknader
-  evt(1, 103,
-    "Julmarknad på Stortorget",
-    "Traditionell julmarknad med glögg, pepparkakor, hantverk och julklappar. Jultomten delar ut godis till barnen varje lördag.",
-    "Helsingborgs stad", "Stortorget", "Helsingborg", "25221", 2, [1004, 1002]),
-  evt(1, 103,
-    "Bondens egen marknad",
-    "Köp direkt från lokala bönder och producenter. Färska grönsaker, ost, bröd, charkuterier och mycket mer från gårdar i Skåne.",
-    "Bondens egen marknad", "Konsul Olssons plats", "Helsingborg", "25224", 9, [1004, 1001]),
-  evt(1, 103,
-    "Antik- och designmarknad",
-    "Skandinaviens största antik- och designmarknad med över 200 utställare. Möbler, konst, smycken och kuriosa från hela Europa.",
-    "Helsingborg Arena", "Mellersta Stenbocksgatan 16", "Helsingborg", "25437", 20, [1003]),
+  evt(1, 103, "Julmarknad på Stortorget", "Traditionell julmarknad med glögg, pepparkakor, hantverk och julklappar.", "Helsingborgs stad", "Stortorget", "Helsingborg", "25221", 2, [1004, 1002]),
+  evt(1, 103, "Bondens egen marknad", "Köp direkt från lokala bönder. Färska grönsaker, ost, bröd och charkuterier från Skåne.", "Bondens egen marknad", "Konsul Olssons plats", "Helsingborg", "25224", 9, [1004, 1001]),
+  evt(1, 103, "Antik- och designmarknad Malmö", "Skandinaviens största antik- och designmarknad med 200+ utställare. Möbler, konst och smycken.", "Malmö Arena", "Hyllie Stationstorg 2", "Malmö", "21532", 15, [1003]),
+  evt(1, 103, "Fiskmarknad i Ängelholm", "Färsk fisk direkt från båtarna. Skaldjur, rökt fisk och lokala delikatesser vid hamnen.", "Ängelholms Fiskeförening", "Hamnen", "Ängelholm", "26234", 11, [1004, 1001]),
+  evt(1, 103, "Keramikmarknad Höganäs", "Höganäs berömda keramiktradition lever vidare. Lokala keramiker säljer sina verk. Demobränning.", "Höganäs Keramik", "Fabriksgatan 2", "Höganäs", "26339", 17, [1004]),
 
-  // ── Kategori 2: Idrott & sport ──────────────────────────────
-  // 201 Sport att utöva
-  evt(2, 201,
-    "Parkrun Helsingborg",
-    "Gratis 5 km löpning varje lördag morgon i Pålsjö Skog. Alla välkomna oavsett tempo — spring, jogga eller gå. Registrera dig på parkrun.se.",
-    "Parkrun Sverige", "Pålsjö Skog", "Helsingborg", "25225", 1, [1001, 1004]),
-  evt(2, 201,
-    "Strandloppet i Ria",
-    "10 km löpning längs kusten från Råå hamn till Ria. Fantastisk utsikt över Öresund. Anmälan via hemsidan, begränsat antal platser.",
-    "Helsingborgs Idrottsförening", "Råå hamn", "Helsingborg", "25270", 8, [1004]),
-  evt(2, 201,
-    "Simutmaningen på Tropical Beach",
-    "Tävla i simning på 200m, 400m eller 1500m i Tropical Beach äventyrsbad. Alla åldersklasser. Rullstolsanpassade omklädningsrum.",
-    "Helsingborgs Simsällskap", "Gröningen 1", "Helsingborg", "25220", 15, [1003, 1006]),
+  // ══════════════════════════════════════════════════════════════
+  // Kategori 3: Underhållning
+  // ══════════════════════════════════════════════════════════════
 
-  // 202 Sport att se på
-  evt(2, 202,
-    "HIF mot Djurgården — Allsvenskan",
-    "Allsvensk fotboll på Olympia. Helsingborgs IF tar emot Djurgårdens IF i en spännande ligamatch. Biljetterna säljs på hif.se.",
-    "Helsingborgs IF", "Olympiavägen 1", "Helsingborg", "25438", 4, [1004]),
-  evt(2, 202,
-    "Rögle BK mot Frölunda HC — SHL",
-    "Dags för match i SHL! Nedslag mot Frölunda i Catena Arena. En av säsongens hetaste hockeymatcher i nordvästra Skåne.",
-    "Rögle BK", "Ishallsvägen", "Ängelholm", "26254", 11, [1003]),
-  evt(2, 202,
-    "Helsingborg Marathon",
-    "Helsingborgs årliga maratontävling med sträckor på 5 km, halvmaraton och fullt maraton. Banan går genom stadens vackraste delar.",
-    "Helsingborg Marathon", "Hamntorget 1", "Helsingborg", "25218", 22, [1004, 1006]),
-
-  // 203 Sport att prova
-  evt(2, 203,
-    "Prova-på padel — gratis introduktion",
-    "Kom och testa padel med våra instruktörer. Vi lånar ut racket och bollar. Ingen förkunskap krävs, alla nivåer välkomna.",
-    "Padel Center Helsingborg", "Ättekullsvägen 26", "Helsingborg", "25268", 6, [1001, 1003]),
-  evt(2, 203,
-    "Segling för nybörjare",
-    "Lär dig grunderna i segling med erfarna instruktörer från Helsingborgs Segelsällskap. Båtar och flytvästar ingår. Passa på i sommar!",
-    "Helsingborgs Segelsällskap", "Parapeten 24", "Helsingborg", "25220", 10, [1004, 1002]),
-  evt(2, 203,
-    "Klätterkväll på Klättercentret",
-    "Prova bouldering och topprepsklättring under kunnig ledning. Utrustning ingår. Barn från 6 år med vuxen. Boka via hemsidan.",
-    "Klättercentret Helsingborg", "Garnisonsgatan 53", "Helsingborg", "25466", 17, [1003, 1002]),
-
-  // ── Kategori 3: Underhållning ───────────────────────────────
   // 301 Bio & film
-  evt(3, 301,
-    "Utomhusbio i Stadsparken",
-    "Gratis filmvisning under bar himmel i Helsingborgs Stadspark. Ta med filt och picknick och njut av en svensk filmklassiker.",
-    "Helsingborgs stad", "Stadsparken", "Helsingborg", "25234", 3, [1001, 1004, 1002]),
-  evt(3, 301,
-    "Filmfestival på Dunkers",
-    "Tre dagars filmfestival med fokus på skandinavisk film. Visningar, panelsamtal med regissörer och filmquiz. Biljetter på dunkers.se.",
-    "Dunkers kulturhus", "Kungsgatan 11", "Helsingborg", "25221", 13, [1003]),
-  evt(3, 301,
-    "Barnfilmsdag på Röda Kvarn",
-    "Specialprogram för de yngsta biobesökarna med animerade filmer och popcornfest. Anpassat för barn 3–10 år. Seniorer gratis.",
-    "Filmstaden Helsingborg", "Bruksgatan 18", "Helsingborg", "25221", 19, [1003, 1002, 1005]),
+  evt(3, 301, "Utomhusbio i Stadsparken", "Gratis filmvisning under bar himmel. Ta med filt och picknick — svensk filmklassiker.", "Helsingborgs stad", "Stadsparken", "Helsingborg", "25234", 3, [1001, 1004, 1002]),
+  evt(3, 301, "Filmfestival på Dunkers", "Tre dagars filmfestival med skandinavisk film. Visningar, panelsamtal med regissörer.", "Dunkers kulturhus", "Kungsgatan 11", "Helsingborg", "25221", 13, [1003]),
+  evt(3, 301, "Barnfilmsdag i Lund", "Specialprogram för barn med animerade filmer och popcornfest. Anpassat för barn 3–10 år.", "Filmstaden Lund", "Botulfsgatan 1", "Lund", "22100", 19, [1003, 1002, 1005]),
+  evt(3, 301, "Dokumentärfilmkväll Malmö", "Visning av prisbelönt dokumentärfilm följd av samtal med regissören. Fri entré.", "Panora Bio", "Friisgatan 19D", "Malmö", "21146", 8, [1003, 1001]),
 
   // 302 Musik & konserter
-  evt(3, 302,
-    "Konsert på Sofiero Slott",
-    "Livemusik i den vackra miljön på Sofieros slottspark. Ta med en picknickfilt och njut av sommarkvällen med akustisk musik och solnedgång.",
-    "Sofiero Slott", "Sofiero Slottsväg 131", "Helsingborg", "25489", 2, [1004]),
-  evt(3, 302,
-    "Jazz på Dunkers kulturhus",
-    "Internationella och svenska jazzmusiker uppträder i Dunkers intima konsertsal. Kvällens gäst: Nils Landgren Funk Unit.",
-    "Dunkers kulturhus", "Kungsgatan 11", "Helsingborg", "25221", 8, [1003, 1006]),
-  evt(3, 302,
-    "Sommarkonsert i Ramlösa Brunnspark",
-    "Gratis utomhuskonsert i den idylliska Ramlösa Brunnspark. Helsingborgs Symfoniorkester spelar klassiska favoriter under öppen himmel.",
-    "Helsingborgs Konserthus", "Ramlösa Brunnspark", "Helsingborg", "25660", 16, [1001, 1004]),
+  evt(3, 302, "Konsert på Sofiero Slott", "Livemusik i slottsparken. Picknickfilt och sommarkväll med akustisk musik och solnedgång.", "Sofiero Slott", "Sofiero Slottsväg 131", "Helsingborg", "25489", 2, [1004]),
+  evt(3, 302, "Jazz på Dunkers kulturhus", "Internationella jazzmusiker i Dunkers intima konsertsal. Kvällens gäst: Nils Landgren Funk Unit.", "Dunkers kulturhus", "Kungsgatan 11", "Helsingborg", "25221", 8, [1003, 1006]),
+  evt(3, 302, "Sommarkonsert i Ramlösa", "Gratis utomhuskonsert i idylliska Ramlösa Brunnspark. Symfoniorkestern spelar klassiska favoriter.", "Helsingborgs Konserthus", "Ramlösa Brunnspark", "Helsingborg", "25660", 16, [1001, 1004]),
+  evt(3, 302, "Livekonsert på Babel Malmö", "Indie-rock från skandinaviska band. Ståplats, biljetter via hemsidan.", "Babel Malmö", "Spångatan 38", "Malmö", "21124", 6, [1003]),
+  evt(3, 302, "Folkmusikkväll i Ängelholm", "Traditionell svensk folkmusik med fiol, nyckelharpa och dragspel. Dansband efteråt.", "Ängelholms Folkets Hus", "Storgatan 40", "Ängelholm", "26232", 10, [1003, 1005]),
 
   // 303 Teater & shower
-  evt(3, 303,
-    "Hamlet på Helsingborgs Stadsteater",
-    "Shakespeares klassiker i modern tappning på Helsingborgs Stadsteater. Regi: Sofia Jupither. Rullstolsplatser finns i salongen.",
-    "Helsingborgs Stadsteater", "Karl Johans gata 1", "Helsingborg", "25221", 5, [1003, 1006]),
-  evt(3, 303,
-    "Ståuppkväll på The Tivoli",
-    "Skånes roligaste komiker samlas för en kväll fylld av skratt. Tre akter med paus. Mingel och bar. Åldersgräns 18 år.",
-    "The Tivoli", "Karl Krooks gata 2", "Helsingborg", "25237", 10, [1003]),
-  evt(3, 303,
-    "Barnteater: Pippi Långstrump",
-    "Astrid Lindgrens älskade Pippi Långstrump lever på scenen! En föreställning för hela familjen med sång, dans och bus.",
-    "Helsingborgs Stadsteater", "Karl Johans gata 1", "Helsingborg", "25221", 21, [1003, 1002]),
+  evt(3, 303, "Hamlet på Stadsteatern", "Shakespeares klassiker i modern tappning. Regi: Sofia Jupither. Rullstolsplatser finns.", "Helsingborgs Stadsteater", "Karl Johans gata 1", "Helsingborg", "25221", 5, [1003, 1006]),
+  evt(3, 303, "Ståuppkväll i Malmö", "Skånes roligaste komiker. Tre akter med paus. Mingel och bar. Åldersgräns 18 år.", "The Tivoli", "Södergatan 15", "Malmö", "21134", 10, [1003]),
+  evt(3, 303, "Barnteater: Pippi Långstrump", "Astrid Lindgrens älskade Pippi lever på scenen! Sång, dans och bus för hela familjen.", "Helsingborgs Stadsteater", "Karl Johans gata 1", "Helsingborg", "25221", 21, [1003, 1002]),
+  evt(3, 303, "Improvisationsteater Lund", "Spontan teater baserad på publikens förslag. Varje föreställning är unik! Alla åldrar.", "Lunds Studentteater", "Sölvegatan 22", "Lund", "22100", 15, [1003, 1001]),
 
-  // ── Kategori 4: Kultur & sevärdheter ────────────────────────
-  // 401 Guidade turer
-  evt(4, 401,
-    "Historisk stadsvandring i Helsingborg",
-    "Följ med på en guidad vandring genom Helsingborgs 900-åriga historia. Från Kärnan till hamnen — berättelser om kungar, krig och handel.",
-    "Helsingborgs Turistbyrå", "Stortorget 17", "Helsingborg", "25221", 1, [1004, 1005]),
-  evt(4, 401,
-    "Guidad tur på Kärnan",
-    "Utforska det medeltida tornet Kärnan med en kunnig guide. Lär dig om tornets historia och njut av panoramautsikt över Öresund och Danmark.",
-    "Helsingborgs museer", "Slottshagen", "Helsingborg", "25221", 7, [1004]),
-  evt(4, 401,
-    "Slottsvandring på Sofiero",
-    "Guidad tur genom Sofiero Slotts vackra trädgårdar och salar. Hör berättelser om kungafamiljens sommarnöjen och parkens unika växtsamling.",
-    "Sofiero Slott", "Sofiero Slottsväg 131", "Helsingborg", "25489", 14, [1004, 1006]),
+  // ══════════════════════════════════════════════════════════════
+  // Kategori 2: Idrott & sport
+  // ══════════════════════════════════════════════════════════════
 
-  // 402 Konst & gallerier
-  evt(4, 402,
-    "Utställning: Havet och vi",
-    "En interaktiv utställning om Öresunds historia och framtid på Dunkers kulturhus. Perfekt för skolklasser och nyfikna besökare i alla åldrar.",
-    "Dunkers kulturhus", "Kungsgatan 11", "Helsingborg", "25221", 4, [1003, 1002, 1006]),
-  evt(4, 402,
-    "Konstnatt Helsingborg",
-    "Gallerier och ateljéer i hela staden håller öppet en kväll. Gratis entré, vernissage och samtal med konstnärer. Kartor delas ut på Stortorget.",
-    "Helsingborgs Konstförening", "Stortorget 17", "Helsingborg", "25221", 9, [1001, 1003]),
-  evt(4, 402,
-    "Gatukonstvandring i Söder",
-    "Upptäck Helsingborgs bästa gatukonst och muralmålningar på en guidad vandring genom södra staden. Gratis, ingen anmälan krävs.",
-    "Street Art Helsingborg", "Södergatan 12", "Helsingborg", "25225", 18, [1001, 1004]),
+  // 201 Sport att utöva
+  evt(2, 201, "Parkrun Helsingborg", "Gratis 5 km löpning varje lördag i Pålsjö Skog. Alla välkomna — spring, jogga eller gå.", "Parkrun Sverige", "Pålsjö Skog", "Helsingborg", "25225", 1, [1001, 1004]),
+  evt(2, 201, "Strandloppet i Ria", "10 km löpning längs kusten från Råå hamn. Fantastisk utsikt över Öresund.", "Helsingborgs IF", "Råå hamn", "Helsingborg", "25270", 8, [1004]),
+  evt(2, 201, "Yoga i Slottsträdgården Malmö", "Utomhusyoga varje söndag morgon. Ta med egen matta. Alla nivåer välkomna. Gratis.", "Yoga Malmö", "Slottsträdgården", "Malmö", "21148", 4, [1001, 1004]),
+  evt(2, 201, "Löparträning Landskrona", "Grupplöpning 5–10 km längs kusten. Nybörjare och erfarna. Samling vid hamnen.", "Landskrona Löparklubb", "Hamnen", "Landskrona", "26131", 6, [1001, 1004]),
 
-  // 403 Museer & sevärdheter
-  evt(4, 403,
-    "Fredriksdals friluftsmuseum — familjedag",
-    "Upplev 1800-talets Skåne på Fredriksdals friluftsmuseum. Hästar, getter, traditionellt hantverk och gammaldags lekar för barnen.",
-    "Fredriksdals museer och trädgårdar", "Gisela Trapps väg 1", "Helsingborg", "25431", 2, [1004, 1002]),
-  evt(4, 403,
-    "Landskrona Museum — vikingautställning",
-    "Ny utställning om vikingatiden i nordvästra Skåne. Originalfynd, interaktiva stationer och visningar för skolor.",
-    "Landskrona Museum", "Slottsgatan 1", "Landskrona", "26131", 11, [1003, 1002, 1006]),
-  evt(4, 403,
-    "Maritiman — sjöfartshistoria",
-    "Besök Helsingborgs sjöfartsmuseum med historiska fartyg, navigationsinstrument och berättelser om Öresunds sjöfart genom tiderna.",
-    "Helsingborgs museer", "Hamntorget 1", "Helsingborg", "25218", 20, [1003, 1005]),
+  // 202 Sport att se på
+  evt(2, 202, "HIF mot Djurgården — Allsvenskan", "Allsvensk fotboll på Olympia. HIF tar emot Djurgården. Biljetter på hif.se.", "Helsingborgs IF", "Olympiavägen 1", "Helsingborg", "25438", 4, [1004]),
+  evt(2, 202, "Rögle BK mot Frölunda — SHL", "Hockeymatch i SHL! Catena Arena. En av säsongens hetaste matcher.", "Rögle BK", "Ishallsvägen 1", "Ängelholm", "26254", 11, [1003]),
+  evt(2, 202, "Helsingborg Marathon", "Årlig maratontävling. 5 km, halvmaraton och fullt maraton genom stadens vackraste delar.", "Helsingborg Marathon", "Hamntorget 1", "Helsingborg", "25218", 22, [1004, 1006]),
+  evt(2, 202, "Malmö FF — hemmapremiär", "Allsvensk fotbollspremiär på Stadion. MFF möter Hammarby. Publikfest innan match.", "Malmö FF", "Stadion", "Malmö", "21745", 9, [1004]),
+  evt(2, 202, "Landskrona BoIS — fotboll", "Superettan-match på Landskrona IP. Publikvänlig atmosfär med stå- och sittplats.", "Landskrona BoIS", "Landskrona IP", "Landskrona", "26133", 13, [1004]),
 
-  // ── Kategori 5: Upplevelser & äventyr ───────────────────────
+  // 203 Sport att prova
+  evt(2, 203, "Prova-på padel — gratis", "Testa padel med instruktörer. Racket och bollar lånas ut. Alla nivåer.", "Padel Center Helsingborg", "Ättekullsvägen 26", "Helsingborg", "25268", 6, [1001, 1003]),
+  evt(2, 203, "Segling för nybörjare", "Lär dig grunderna i segling. Båtar och flytvästar ingår. Sommaraktivitet!", "Helsingborgs Segelsällskap", "Parapeten 24", "Helsingborg", "25220", 10, [1004, 1002]),
+  evt(2, 203, "Klätterkväll på Klättercentret", "Prova bouldering och topprepklättring. Utrustning ingår. Barn från 6 år med vuxen.", "Klättercentret Helsingborg", "Garnisonsgatan 53", "Helsingborg", "25466", 17, [1003, 1002]),
+  evt(2, 203, "Surfskola i Höganäs", "Prova surfing vid Skånes bästa strand. Våtdräkt och bräda ingår. Nybörjarkurs 2 timmar.", "Surf Skåne", "Strandbadsvägen", "Höganäs", "26339", 7, [1004, 1002]),
+  evt(2, 203, "Prova på disc golf Lund", "Introduktion till disc golf i Lunds fina bana. Discar att låna. Gratis, drop-in.", "Lunds Frisbeeklubb", "Höjeådalen", "Lund", "22100", 5, [1001, 1004]),
+
+  // ══════════════════════════════════════════════════════════════
+  // Kategori 5: Upplevelser & äventyr
+  // ══════════════════════════════════════════════════════════════
+
   // 501 Parker & stigar
-  evt(5, 501,
-    "Vandring i Söderåsens nationalpark",
-    "Guidad vandring genom Söderåsens dramatiska raviner och urskogar. Sträckan är 8 km och tar cirka 4 timmar. Ta med egen matsäck.",
-    "Naturum Söderåsen", "Skäralid", "Ljungbyhed", "26053", 3, [1004, 1001]),
-  evt(5, 501,
-    "Promenad i Fredriksdals trädgårdar",
-    "Botanisk vandring i Fredriksdals vackra trädgårdar med expert som berättar om växter, kryddgårdar och historiska odlingsmetoder.",
-    "Fredriksdals museer och trädgårdar", "Gisela Trapps väg 1", "Helsingborg", "25431", 8, [1004, 1005]),
-  evt(5, 501,
-    "Kvällspromenad i Ramlösa Brunnspark",
-    "Guidad kvällspromenad i den atmosfäriska Ramlösa Brunnspark. Lär dig om parkens historia som kurort och njut av den fridfulla naturen.",
-    "Helsingborgs stad", "Ramlösa Brunnspark", "Helsingborg", "25660", 15, [1004]),
+  evt(5, 501, "Vandring i Söderåsen", "Guidad vandring genom dramatiska raviner och urskogar. 8 km, ca 4 timmar. Ta med matsäck.", "Naturum Söderåsen", "Skäralid", "Höganäs", "26353", 3, [1004, 1001]),
+  evt(5, 501, "Promenad i Fredriksdals trädgårdar", "Botanisk vandring med expert. Växter, kryddgårdar och historiska odlingsmetoder.", "Fredriksdals museer", "Gisela Trapps väg 1", "Helsingborg", "25431", 8, [1004, 1005]),
+  evt(5, 501, "Kvällspromenad i Ramlösa", "Guidad kvällspromenad i atmosfäriska Ramlösa Brunnspark. Parkens historia som kurort.", "Helsingborgs stad", "Ramlösa Brunnspark", "Helsingborg", "25660", 15, [1004]),
+  evt(5, 501, "Strandvandring Kullaberg", "Guidad vandring längs Kullabergs dramatiska kust. Klippor, grottor och havsutsikt. 6 km.", "Kullabergs Naturreservat", "Kullaberg", "Höganäs", "26398", 11, [1004]),
+  evt(5, 501, "Skogsbad i Dalby Söderskog", "Upplev skogens läkande kraft med guidad skogsbadspromenad. Mindfulness i naturen.", "Lunds Naturförening", "Dalby Söderskog", "Lund", "22466", 18, [1004]),
 
   // 502 Mat & dryck
-  evt(5, 502,
-    "Helsingborg Food Walk",
-    "Kulinarisk stadsvandring med smakprov på fem olika restauranger i centrala Helsingborg. Upptäck stadens matscen med en lokal guide.",
-    "Helsingborg Food Tours", "Stortorget 17", "Helsingborg", "25221", 5, [1004]),
-  evt(5, 502,
-    "Ölprovning på Helsingborgs Bryggeri",
-    "Prova sex lokala hantverksöl med bryggmästaren som guide. Lär dig om bryggprocessen och vad som gör skånsk öl unik. Ost och bröd ingår.",
-    "Helsingborgs Bryggeri", "Bergaliden 30", "Helsingborg", "25244", 12, [1003]),
-  evt(5, 502,
-    "Matlagningskväll — skånsk husmanskost",
-    "Laga klassisk skånsk mat som äggakaka, spettekaka och kroppkakor under ledning av kock. Alla ingredienser ingår, ta med hem det du lagat!",
-    "Ebbas Fik", "Bruksgatan 20", "Helsingborg", "25221", 19, [1003]),
+  evt(5, 502, "Helsingborg Food Walk", "Kulinarisk stadsvandring med smakprov på fem restauranger. Upptäck matscenen.", "Helsingborg Food Tours", "Stortorget 17", "Helsingborg", "25221", 5, [1004]),
+  evt(5, 502, "Ölprovning på Helsingborgs Bryggeri", "Sex lokala hantverksöl med bryggmästaren som guide. Ost och bröd ingår.", "Helsingborgs Bryggeri", "Bergaliden 30", "Helsingborg", "25244", 12, [1003]),
+  evt(5, 502, "Matlagningskväll — skånsk husmanskost", "Laga äggakaka, spettekaka och kroppkakor. Alla ingredienser ingår.", "Ebbas Fik", "Bruksgatan 20", "Helsingborg", "25221", 19, [1003]),
+  evt(5, 502, "Vinprovning i Landskrona", "Prova skånska viner från lokala vingårdar. Ost och charkuterier ingår. 18+.", "Landskrona Vingård", "Borstahusen", "Landskrona", "26178", 9, [1003]),
+  evt(5, 502, "Streetfood-festival Malmö", "Mat från hela världen i Folkets Park. 30+ foodtrucks, livemusik och barnaktiviteter.", "Malmö Streetfood", "Folkets Park", "Malmö", "21445", 14, [1004, 1002, 1001]),
 
   // 503 Utflykter & äventyr
-  evt(5, 503,
-    "Kajaktur till Ven",
-    "Paddla kajak över Öresund till ön Ven. Erfarna guider, lunch på ön och transport tillbaka. Grundläggande simkunnighet krävs.",
-    "Paddle & Explore", "Råå hamn", "Helsingborg", "25270", 6, [1004]),
-  evt(5, 503,
-    "Segelbåtstur i Öresund",
-    "Upplev Öresund från vattnet på en klassisk segelbåt. Tvåtimmars tur med utsikt mot Kronborg, Ven och Helsingborgs skyline.",
-    "Helsingborgs Segelsällskap", "Parapeten 24", "Helsingborg", "25220", 14, [1004]),
-  evt(5, 503,
-    "Äventyrsparken — klätterbana i skogen",
-    "Utmana dig själv i höghöjdsbanor bland trädtopparna. Banor för alla åldrar, från 4 år och uppåt. Säkerhetsutrustning ingår.",
-    "Äventyrsparken Skåne", "Rååvägen 10", "Helsingborg", "25265", 22, [1004, 1002]),
+  evt(5, 503, "Kajaktur till Ven", "Paddla kajak till ön Ven. Erfarna guider, lunch på ön. Grundläggande simkunnighet krävs.", "Paddle & Explore", "Råå hamn", "Helsingborg", "25270", 6, [1004]),
+  evt(5, 503, "Segelbåtstur i Öresund", "Upplev Öresund från vattnet. Tvåtimmars tur med utsikt mot Kronborg och Ven.", "Helsingborgs Segelsällskap", "Parapeten 24", "Helsingborg", "25220", 14, [1004]),
+  evt(5, 503, "Äventyrsparken Landskrona", "Klätterbana i trädtopparna. Banor för alla åldrar, från 4 år. Säkerhetsutrustning ingår.", "Äventyrsparken Skåne", "Rååvägen 10", "Landskrona", "26135", 22, [1004, 1002]),
+  evt(5, 503, "Cykeltur Helsingborg–Höganäs", "Guidad cykeltur längs kusten. 30 km med fikapauser. Cykel kan hyras. Alla nivåer.", "Cykelturism Skåne", "Hamntorget", "Helsingborg", "25218", 10, [1004]),
+  evt(5, 503, "Båttur i Lundåkrabukten", "Rundtur med fiskebåt. Se sälar, fåglar och kustlandskapet. Familjevänligt.", "Ängelholms Båtcharter", "Skeppargatan", "Ängelholm", "26234", 16, [1004, 1002]),
 
-  // ── Kategori 6: Lära & utforska ─────────────────────────────
+  // ══════════════════════════════════════════════════════════════
+  // Kategori 4: Kultur & sevärdheter
+  // ══════════════════════════════════════════════════════════════
+
+  // 401 Guidade turer
+  evt(4, 401, "Historisk stadsvandring Helsingborg", "Guidad vandring genom 900 års historia. Från Kärnan till hamnen — kungar, krig och handel.", "Helsingborgs Turistbyrå", "Stortorget 17", "Helsingborg", "25221", 1, [1004, 1005]),
+  evt(4, 401, "Guidad tur på Kärnan", "Utforska det medeltida tornet med kunnig guide. Panoramautsikt över Öresund.", "Helsingborgs museer", "Slottshagen", "Helsingborg", "25221", 7, [1004]),
+  evt(4, 401, "Slottsvandring på Sofiero", "Guidad tur genom slottets trädgårdar och salar. Kungafamiljens sommarnöjen.", "Sofiero Slott", "Sofiero Slottsväg 131", "Helsingborg", "25489", 14, [1004, 1006]),
+  evt(4, 401, "Spökvandring i Landskrona", "Guidad kvällsvandring bland stadens spökhistorier och myter. Ficklampa rekommenderas.", "Visit Landskrona", "Stortorget", "Landskrona", "26131", 5, [1004]),
+  evt(4, 401, "Rundvandring i Lunds Domkyrka", "Upptäck Nordens mest besökta kyrka med auktoriserad guide. 800 år av historia.", "Lunds Domkyrkoförsamling", "Kyrkogatan 4", "Lund", "22100", 11, [1003, 1006]),
+
+  // 402 Konst & gallerier
+  evt(4, 402, "Utställning: Havet och vi", "Interaktiv utställning om Öresunds historia och framtid. Perfekt för skolklasser.", "Dunkers kulturhus", "Kungsgatan 11", "Helsingborg", "25221", 4, [1003, 1002, 1006]),
+  evt(4, 402, "Konstnatt Helsingborg", "Gallerier och ateljéer i hela staden håller öppet. Gratis vernissage med konstnärer.", "Helsingborgs Konstförening", "Stortorget 17", "Helsingborg", "25221", 9, [1001, 1003]),
+  evt(4, 402, "Gatukonstvandring i Söder", "Upptäck gatukonst och muralmålningar. Gratis guidad vandring, ingen anmälan krävs.", "Street Art Helsingborg", "Södergatan 12", "Helsingborg", "25225", 18, [1001, 1004]),
+  evt(4, 402, "Moderna Museet Malmö — ny utställning", "Samtidskonst från nordiska konstnärer. Interaktiva installationer och videoverk.", "Moderna Museet Malmö", "Gasverksgatan 22", "Malmö", "21131", 6, [1003, 1006]),
+  evt(4, 402, "Konstuställning Höganäs", "Lokala konstnärer visar målningar, skulpturer och keramik. Vernissage med vin.", "Höganäs Konsthall", "Storgatan 19", "Höganäs", "26332", 13, [1003]),
+
+  // 403 Museer & sevärdheter
+  evt(4, 403, "Fredriksdals friluftsmuseum — familjedag", "1800-talets Skåne med hästar, getter, hantverk och gammaldags lekar.", "Fredriksdals museer", "Gisela Trapps väg 1", "Helsingborg", "25431", 2, [1004, 1002]),
+  evt(4, 403, "Landskrona Museum — vikingautställning", "Vikingatiden i NV Skåne. Originalfynd, interaktiva stationer.", "Landskrona Museum", "Slottsgatan 1", "Landskrona", "26131", 11, [1003, 1002, 1006]),
+  evt(4, 403, "Kulturen i Lund", "Skandinaviens äldsta friluftsmuseum. Historiska hus, trädgårdar och utställningar.", "Kulturen", "Tegnérsplatsen", "Lund", "22350", 8, [1004, 1002]),
+  evt(4, 403, "Malmö Museer — slottet", "Utforska Malmöhus slott med konst-, natur- och stadshistoria under ett tak.", "Malmö Museer", "Malmöhusvägen 6", "Malmö", "21118", 16, [1003, 1002, 1006]),
+
+  // ══════════════════════════════════════════════════════════════
+  // Kategori 6: Lära & utforska
+  // ══════════════════════════════════════════════════════════════
+
   // 601 Föreläsningar
-  evt(6, 601,
-    "Föreläsning: Hållbar stadsutveckling",
-    "Professor Maria Lindström föreläser om framtidens hållbara stadsplanering med exempel från Helsingborgs H22-projekt. Fri entré.",
-    "Campus Helsingborg", "Universitetsplatsen 2", "Helsingborg", "25148", 2, [1003, 1001]),
-  evt(6, 601,
-    "AI-kväll på Campus Helsingborg",
-    "Hur förändrar artificiell intelligens vårt samhälle? Forskare från Lunds universitet presenterar den senaste forskningen. Paneldiskussion efteråt.",
-    "Lunds universitet Campus Helsingborg", "Universitetsplatsen 2", "Helsingborg", "25148", 9, [1003]),
-  evt(6, 601,
-    "Helsingborgs historia — från Kärnan till H22",
-    "Stadsantikvarie Peter Nilsson tar dig genom 900 år av Helsingborgs historia. Bildspel, anekdoter och tid för frågor. Anpassat för seniorer.",
-    "Stadsbiblioteket Helsingborg", "Bollbrogatan 1", "Helsingborg", "25220", 16, [1003, 1005]),
+  evt(6, 601, "Föreläsning: Hållbar stadsutveckling", "Professor Maria Lindström om framtidens stadsplanering med H22-exempel. Fri entré.", "Campus Helsingborg", "Universitetsplatsen 2", "Helsingborg", "25148", 2, [1003, 1001]),
+  evt(6, 601, "AI-kväll på Campus", "Hur förändrar AI vårt samhälle? Forskare från Lunds universitet presenterar ny forskning.", "Lunds universitet", "Universitetsplatsen 2", "Helsingborg", "25148", 9, [1003]),
+  evt(6, 601, "Helsingborgs historia — föreläsning", "Stadsantikvarie Peter Nilsson: 900 år av historia. Bildspel, anekdoter och frågestund.", "Stadsbiblioteket", "Bollbrogatan 1", "Helsingborg", "25220", 16, [1003, 1005]),
+  evt(6, 601, "Klimatföreläsning Lund", "Forskare från LUCSUS om klimatanpassning i Skåne. Paneldiskussion efter. Gratis.", "Lunds universitet", "Geocentrum", "Lund", "22100", 7, [1003, 1001]),
+  evt(6, 601, "Författarkväll Malmö", "Prisbelönt författare läser ur ny roman och berättar om skrivprocessen. Signering.", "Malmö Stadsbibliotek", "Kung Oscars väg 11", "Malmö", "21114", 13, [1003]),
 
   // 602 Lär dig...
-  evt(6, 602,
-    "Keramikverkstad på Kulturhuset",
-    "Lär dig grunderna i keramik och dreja din egen skål eller kopp. Material och bränning ingår. Inga förkunskaper krävs.",
-    "Dunkers kulturhus", "Kungsgatan 11", "Helsingborg", "25221", 4, [1003]),
-  evt(6, 602,
-    "Nybörjarkurs i akvarellmålning",
-    "Sex veckor med akvarellmålning för nybörjare. Lär dig teknik, färglära och komposition. Material ingår i kursavgiften.",
-    "Helsingborgs Konstskola", "Nedre Långvinkelsgatan 3", "Helsingborg", "25221", 7, [1003]),
-  evt(6, 602,
-    "Fotovandring i Helsingborg",
-    "Lär dig ta bättre foton med din mobil eller kamera under en guidad vandring. Tips om komposition, ljus och redigering.",
-    "Fotoklubben Helsingborg", "Stortorget 17", "Helsingborg", "25221", 13, [1004]),
+  evt(6, 602, "Keramikverkstad på Kulturhuset", "Lär dig grunderna i keramik och dreja en skål eller kopp. Material och bränning ingår.", "Dunkers kulturhus", "Kungsgatan 11", "Helsingborg", "25221", 4, [1003]),
+  evt(6, 602, "Nybörjarkurs i akvarellmålning", "Sex veckor med akvarellmålning. Teknik, färglära och komposition. Material ingår.", "Helsingborgs Konstskola", "Nedre Långvinkelsgatan 3", "Helsingborg", "25221", 7, [1003]),
+  evt(6, 602, "Fotovandring i Lund", "Lär dig ta bättre foton med mobil eller kamera. Tips om komposition och ljus.", "Fotoklubben Lund", "Stortorget 1", "Lund", "22222", 13, [1004]),
+  evt(6, 602, "Surdegsbröd-workshop", "Baka surdegsbröd från grunden. Lär dig om fermentering och smaksättning. Ta med hem ditt bröd.", "Bageriet Ängelholm", "Storgatan 22", "Ängelholm", "26231", 10, [1003]),
+  evt(6, 602, "Stickkurs för nybörjare", "Lär dig sticka vantar och mössor. Garn och stickor ingår. Fika serveras.", "Höganäs Hemslöjd", "Köpmansgatan 10", "Höganäs", "26332", 15, [1003, 1005]),
 
   // 603 Träffar & möten
-  evt(6, 603,
-    "Brädspelskväll på Café Noir",
-    "Drop-in brädspelskväll varje onsdag. Vi har över 100 spel att välja bland. Gratis att delta, köp gärna fika i caféet.",
-    "Café Noir", "Carl Krooks gata 8", "Helsingborg", "25237", 1, [1003, 1001, 1002]),
-  evt(6, 603,
-    "Tech Meetup Helsingborg",
-    "Nätverksträff för utvecklare, designers och techentusiaster i Helsingborg. Lightning talks, mingel och pizza. Fri entré.",
-    "Mindpark", "Bredgatan 11", "Helsingborg", "25225", 10, [1003, 1001]),
-  evt(6, 603,
-    "Bokcirkel på Stadsbiblioteket",
-    "Månadens bok diskuteras i bibliotekets mysiga läshörna. Alla är välkomna, oavsett om du läst boken eller inte. Kaffe serveras.",
-    "Stadsbiblioteket Helsingborg", "Bollbrogatan 1", "Helsingborg", "25220", 17, [1003, 1005]),
+  evt(6, 603, "Brädspelskväll på Café Noir", "Drop-in brädspelskväll varje onsdag. 100+ spel. Gratis, köp gärna fika.", "Café Noir", "Carl Krooks gata 8", "Helsingborg", "25237", 1, [1003, 1001, 1002]),
+  evt(6, 603, "Tech Meetup Helsingborg", "Nätverksträff för utvecklare, designers och techentusiaster. Lightning talks och pizza. Fri entré.", "Mindpark", "Bredgatan 11", "Helsingborg", "25225", 10, [1003, 1001]),
+  evt(6, 603, "Bokcirkel på Stadsbiblioteket", "Månadens bok diskuteras. Alla välkomna, oavsett om du läst boken. Kaffe serveras.", "Stadsbiblioteket Malmö", "Kung Oscars väg 11", "Malmö", "21114", 17, [1003, 1005]),
+  evt(6, 603, "Språkcafé — svenska för nyanlända", "Öva svenska i avslappnad miljö. Fika ingår. Alla språknivåer välkomna.", "Landskrona Bibliotek", "Rådhustorget 1", "Landskrona", "26131", 5, [1003, 1001, 1006]),
+  evt(6, 603, "Träffpunkt för ensamma föräldrar", "Nätverksträff för ensamstående föräldrar. Barn leker medan vuxna minglar. Fika.", "Ängelholms Familjecentral", "Storgatan 50", "Ängelholm", "26232", 12, [1003, 1002, 1001]),
 
-  // ── Kategori 7: Hälsa & välmående ──────────────────────────
+  // ══════════════════════════════════════════════════════════════
+  // Kategori 7: Hälsa & välmående
+  // ══════════════════════════════════════════════════════════════
+
   // 701 Spa & bad
-  evt(7, 701,
-    "Kallbadhuset — bastu och havsbad",
-    "Njut av traditionellt kallbad vid Helsingborgs anrika kallbadhus. Bastu, avkoppling och havsbad med utsikt mot Danmark. Rullstolsanpassat.",
-    "Pålsjöbaden", "Pålsjövägen", "Helsingborg", "25225", 3, [1004, 1006]),
-  evt(7, 701,
-    "Familjedag på Tropical Beach",
-    "Heldag i äventyrsbad med vattenrutschbanor, vågor och barnpool. Specialpris för familjer. Cafeteria och omklädningsrum finns.",
-    "Tropical Beach", "Gröningen 1", "Helsingborg", "25220", 8, [1003, 1002]),
-  evt(7, 701,
-    "Bastukväll vid havet — Fria Bad",
-    "Vedeldad bastu vid strandkanten, iskallt havsbad och avkoppling under stjärnorna. Handduk ingår. Boka plats i förväg.",
-    "Fria Bad Helsingborg", "Tropical Beach-vägen 2", "Helsingborg", "25220", 15, [1004]),
+  evt(7, 701, "Kallbadhuset — bastu och havsbad", "Traditionellt kallbad vid anrika kallbadhuset. Bastu, avkoppling och havsbad. Rullstolsanpassat.", "Pålsjöbaden", "Pålsjövägen", "Helsingborg", "25225", 3, [1004, 1006]),
+  evt(7, 701, "Familjedag på Tropical Beach", "Heldag i äventyrsbad. Vattenrutschbanor, vågor och barnpool. Specialpris för familjer.", "Tropical Beach", "Gröningen 1", "Helsingborg", "25220", 8, [1003, 1002]),
+  evt(7, 701, "Bastukväll vid havet", "Vedeldad bastu vid strandkanten, havsbad och avkoppling under stjärnorna. Handduk ingår.", "Fria Bad", "Tropical Beach-vägen 2", "Helsingborg", "25220", 15, [1004]),
+  evt(7, 701, "Ribersborgs kallbadhus Malmö", "Klassisk kallbadupplevelse med bastu och havsbad. Öppet hela året.", "Ribban", "Limhamnsvägen", "Malmö", "21614", 5, [1004, 1006]),
+  evt(7, 701, "Spa-dag i Höganäs", "Heldag med massage, ansiktsbehandling och havsvattenpool. Lunch ingår.", "Höganäs Spa", "Strandvägen 1", "Höganäs", "26339", 11, [1003]),
 
   // 702 Stöd & samverkan
-  evt(7, 702,
-    "Föräldraträff på Familjecentralen",
-    "Öppen träff för nyblivna föräldrar med barn 0–1 år. Barnmorska och BVC-sköterska på plats. Fika ingår. Rullstolsanpassat.",
-    "Familjecentralen Helsingborg", "Drottninggatan 14", "Helsingborg", "25221", 5, [1003, 1002, 1006]),
-  evt(7, 702,
-    "Samtalsgrupp för sörjande",
-    "Stödgrupp ledd av utbildad samtalsledare för dig som förlorat en närstående. Sex träffar, en gång i veckan. Kostnadsfritt.",
-    "Svenska Kyrkan Helsingborg", "Mariakyrkan", "Helsingborg", "25221", 12, [1003, 1001]),
-  evt(7, 702,
-    "Seniorträff med föreläsning och fika",
-    "Månatlig seniorträff med inspirerande föreläsningar, fika och möjlighet att träffa nya vänner. Denna gång: digital trygghet.",
-    "Röda Korset Helsingborg", "Kullagatan 23", "Helsingborg", "25221", 19, [1003, 1005, 1006]),
+  evt(7, 702, "Föräldraträff på Familjecentralen", "Öppen träff för nyblivna föräldrar (barn 0–1 år). Barnmorska på plats. Fika ingår.", "Familjecentralen", "Drottninggatan 14", "Helsingborg", "25221", 5, [1003, 1002, 1006]),
+  evt(7, 702, "Samtalsgrupp för sörjande", "Stödgrupp för dig som förlorat en närstående. Sex träffar, en/vecka. Kostnadsfritt.", "Svenska Kyrkan", "Mariakyrkan", "Helsingborg", "25221", 12, [1003, 1001]),
+  evt(7, 702, "Seniorträff med föreläsning", "Månatlig seniorträff med inspiration, fika och nya vänner. Tema: digital trygghet.", "Röda Korset", "Kullagatan 23", "Helsingborg", "25221", 19, [1003, 1005, 1006]),
+  evt(7, 702, "Anhörigstöd Landskrona", "Stödgrupp för dig som vårdar en närstående. Erfarenhetsutbyte och avlastning.", "Landskrona kommun", "Rådhuset", "Landskrona", "26131", 8, [1003, 1001, 1006]),
+  evt(7, 702, "Volontärträff Malmö", "Bli volontär! Introduktionsträff för dig som vill hjälpa till. Många uppdrag att välja bland.", "Volontärbyrån Malmö", "Bergsgatan 20", "Malmö", "21254", 14, [1003, 1001]),
 
   // 703 Trosaktiviteter
-  evt(7, 703,
-    "Mindfulness-meditation i Stadsparken",
-    "Gratis guidad meditation utomhus varje söndagsmorgon. Passar alla nivåer. Ta med egen matta eller filt. Vid regn flyttar vi inomhus.",
-    "Meditations­gruppen Helsingborg", "Stadsparken", "Helsingborg", "25234", 2, [1001, 1004]),
-  evt(7, 703,
-    "Kyrkokonsert i Mariakyrkan",
-    "Helsingborgs Motettkör framför verk av Bach och Händel i den vackra Mariakyrkan. Fri entré, kollekt till välgörenhet.",
-    "Mariakyrkan", "Mariatorget 1", "Helsingborg", "25221", 9, [1003, 1001]),
-  evt(7, 703,
-    "Interreligiös dialogkväll",
-    "Representanter från olika trossamfund samtalar om fred, samexistens och hopp. Öppet för alla, oavsett trosuppfattning. Rullstolsanpassat.",
-    "Helsingborgs Interreligiösa Råd", "Stadsbiblioteket, Bollbrogatan 1", "Helsingborg", "25220", 16, [1003, 1006]),
+  evt(7, 703, "Mindfulness-meditation i Stadsparken", "Gratis guidad meditation utomhus. Alla nivåer. Ta med matta eller filt. Vid regn: inomhus.", "Meditationsgruppen", "Stadsparken", "Helsingborg", "25234", 2, [1001, 1004]),
+  evt(7, 703, "Kyrkokonsert i Mariakyrkan", "Motettkör framför Bach och Händel i vackra Mariakyrkan. Fri entré, kollekt.", "Mariakyrkan", "Mariatorget 1", "Helsingborg", "25221", 9, [1003, 1001]),
+  evt(7, 703, "Interreligiös dialogkväll", "Representanter från trossamfund samtalar om fred och samexistens. Öppet för alla.", "Interreligiösa Rådet", "Stadsbiblioteket", "Helsingborg", "25220", 16, [1003, 1006]),
+  evt(7, 703, "Yoga och meditation Lund", "Kombinerad yoga och meditationsklass i lugn miljö. Nybörjarvänligt. Gratis prova-på.", "Lunds Yogacenter", "Klostergatan 5", "Lund", "22100", 6, [1003, 1001]),
+  evt(7, 703, "Pilgrimsvandring Ängelholm", "Guidad vandring längs pilgrimsleden. Samtal, tystnad och naturnära reflektion.", "Ängelholms Pastorat", "S:t Petri Kyrka", "Ängelholm", "26234", 13, [1004]),
+
+  // ══════════════════════════════════════════════════════════════
+  // Extra events for city coverage (Ängelholm + Höganäs → 10+)
+  // ══════════════════════════════════════════════════════════════
+
+  // Ängelholm extras
+  evt(3, 302, "Jazzkväll i Ängelholm", "Lokala jazzmusiker spelar i Hembygdsparkens musikpaviljong. Medtag picknick. Gratis.", "Ängelholms Jazzförening", "Hembygdsparken", "Ängelholm", "26235", 4, [1004, 1001]),
+  evt(4, 403, "Teknikens Hus Ängelholm", "Interaktivt museum med experiment och uppfinningar. Perfekt för nyfikna barn och vuxna.", "Teknikens Hus", "Järnvägsgatan 5", "Ängelholm", "26231", 8, [1003, 1002]),
+  evt(8, 802, "Barnens lekdag på stranden", "Sandslottstävling, strandlekar och glass. Gratis aktivitet för barn 4–12 år.", "Ängelholms kommun", "Skälderviken", "Ängelholm", "26235", 14, [1004, 1001, 1002]),
+
+  // Höganäs extras
+  evt(4, 401, "Keramikrundtur i Höganäs", "Guidad tur till historiska keramikfabriker och ateljéer. Lär dig om Höganäs keramiktradition.", "Visit Höganäs", "Storgatan 19", "Höganäs", "26332", 4, [1004]),
+  evt(1, 102, "Fiskedag i Mölle hamn", "Prova sportfiske från bryggan. Utrustning att låna. Grillning av fångsten efteråt. Familjevänligt.", "Mölle Fiskeförening", "Mölle hamn", "Höganäs", "26342", 10, [1004, 1002, 1001]),
+  evt(7, 701, "Havsbad vid Skärets badplats", "Organiserad morgonsimning med simledare. Alla nivåer. Fika efteråt i strandkiosken.", "Höganäs Simsällskap", "Skärets badplats", "Höganäs", "26339", 7, [1004, 1001]),
 ];
 
 // ────────────────────────────────────────────────────────────────
-// Client-side filter + paginate helper
+// Client-side filter + sort + paginate helper
 // ────────────────────────────────────────────────────────────────
+
+export type SortMode = "date_asc" | "date_desc" | "alpha_asc";
 
 export interface MockFilter {
   categoryCodes?: number[];
   subcategoryCodes?: number[];
   tagCodes?: number[];
+  searchText?: string;
+  cities?: string[];
+  startDate?: string | null;
+  endDate?: string | null;
+  sortMode?: SortMode;
   pageSize?: number;
 }
 
@@ -426,6 +344,23 @@ export function filterMockEvents(filter: MockFilter = {}): {
   totalCount: number;
 } {
   let result = MOCK_EVENTS;
+
+  if (filter.searchText?.trim()) {
+    const q = filter.searchText.trim().toLowerCase();
+    result = result.filter(
+      (e) =>
+        e.title.toLowerCase().includes(q) ||
+        (e.description && e.description.toLowerCase().includes(q)) ||
+        (e.city && e.city.toLowerCase().includes(q)) ||
+        (e.organiser && e.organiser.toLowerCase().includes(q)),
+    );
+  }
+
+  if (filter.cities?.length) {
+    result = result.filter((e) =>
+      e.city ? filter.cities!.includes(e.city) : false,
+    );
+  }
 
   if (filter.categoryCodes?.length) {
     result = result.filter((e) =>
@@ -445,15 +380,41 @@ export function filterMockEvents(filter: MockFilter = {}): {
     );
   }
 
-  // Sort by startDate ascending
+  if (filter.startDate) {
+    const start = new Date(filter.startDate).getTime();
+    result = result.filter((e) => {
+      if (!e.startDate) return true;
+      return new Date(e.startDate).getTime() >= start;
+    });
+  }
+
+  if (filter.endDate) {
+    const end = new Date(filter.endDate).getTime() + 86400000; // include end day
+    result = result.filter((e) => {
+      if (!e.startDate) return true;
+      return new Date(e.startDate).getTime() <= end;
+    });
+  }
+
+  // Sort
+  const sortMode = filter.sortMode ?? "date_asc";
   result = [...result].sort((a, b) => {
+    if (sortMode === "alpha_asc") {
+      return a.title.localeCompare(b.title, "sv");
+    }
+    if (sortMode === "date_desc") {
+      if (!a.startDate) return 1;
+      if (!b.startDate) return -1;
+      return new Date(b.startDate).getTime() - new Date(a.startDate).getTime();
+    }
+    // date_asc (default)
     if (!a.startDate) return 1;
     if (!b.startDate) return -1;
     return new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
   });
 
   const totalCount = result.length;
-  const pageSize = filter.pageSize ?? 30;
+  const pageSize = filter.pageSize ?? 50;
 
   return {
     items: result.slice(0, pageSize),

--- a/src/components/preview/screens/EventDetailScreen.tsx
+++ b/src/components/preview/screens/EventDetailScreen.tsx
@@ -4,15 +4,22 @@ import {
   BRAND,
   CATEGORY_COLORS,
   CATEGORY_GRADIENTS,
-  CATEGORY_TINTS,
   CATEGORY_SHORT_LABELS,
+  FontFamily,
+  Typography,
+  Spacing,
+  Radii,
+  Shadows,
+  Neutral,
+  GodoYellow,
+  Surface,
 } from "../constants";
 import { MOCK_EVENTS } from "../mockEvents";
 import {
   ArrowLeft,
   Share2,
+  Heart,
   MapPin,
-  CalendarDays,
   Clock,
   ExternalLink,
   User,
@@ -31,20 +38,26 @@ export function EventDetailScreen({ eventId, onBack }: EventDetailScreenProps) {
 
   if (!event) {
     return (
-      <div className="flex flex-col items-center justify-center py-20 gap-3">
+      <div className="flex flex-col items-center justify-center py-20 gap-3" style={{ fontFamily: FontFamily.body }}>
         <div
-          className="w-[48px] h-[48px] rounded-full flex items-center justify-center"
-          style={{ backgroundColor: BRAND.neutral100 }}
+          className="flex items-center justify-center rounded-full"
+          style={{ width: 48, height: 48, backgroundColor: Neutral[100] }}
         >
-          <MapPin size={20} style={{ color: BRAND.textSecondary }} />
+          <MapPin size={20} style={{ color: Neutral[500] }} />
         </div>
-        <p className="text-[13px]" style={{ color: BRAND.textSecondary }}>
+        <p style={{ fontSize: Typography.meta.size, color: Neutral[500] }}>
           Evenemanget hittades inte
         </p>
         <button
           onClick={onBack}
-          className="text-[13px] font-semibold px-4 py-2 rounded-full"
-          style={{ backgroundColor: BRAND.yellow, color: BRAND.onPrimary }}
+          className="px-4 py-2"
+          style={{
+            fontSize: Typography.meta.size,
+            fontWeight: 600,
+            borderRadius: Radii.pill,
+            backgroundColor: GodoYellow[500],
+            color: Surface.onPrimary,
+          }}
         >
           Gå tillbaka
         </button>
@@ -54,8 +67,6 @@ export function EventDetailScreen({ eventId, onBack }: EventDetailScreenProps) {
 
   const categoryCode = event.categories?.[0]?.code ?? 1;
   const gradient = CATEGORY_GRADIENTS[categoryCode] ?? CATEGORY_GRADIENTS[1];
-  const color = CATEGORY_COLORS[categoryCode] ?? CATEGORY_COLORS[1];
-  const tint = CATEGORY_TINTS[categoryCode] ?? CATEGORY_TINTS[1];
 
   const dateLabel = event.startDate
     ? format(new Date(event.startDate), "EEEE d MMMM yyyy", { locale: sv })
@@ -83,145 +94,105 @@ export function EventDetailScreen({ eventId, onBack }: EventDetailScreenProps) {
         : "";
 
   return (
-    <div className="relative flex flex-col" style={{ backgroundColor: BRAND.yellow, minHeight: "100%" }}>
-      {/* Hero section — 300dp with category gradient */}
-      <div className="relative" style={{ height: "260px" }}>
-        {/* Category gradient background */}
+    <div className="relative flex flex-col" style={{ minHeight: "100%", fontFamily: FontFamily.body }}>
+      {/* Hero section — 300px with category gradient */}
+      <div className="relative" style={{ height: 300 }}>
         <div
           className="absolute inset-0"
-          style={{
-            background: `linear-gradient(135deg, ${gradient[0]}, ${gradient[1]})`,
-          }}
+          style={{ background: `linear-gradient(135deg, ${gradient[0]}, ${gradient[1]})` }}
         />
-        {/* Dark scrim overlay — bottom vignette */}
         <div
           className="absolute inset-0"
-          style={{
-            background: "linear-gradient(to bottom, transparent 30%, rgba(0,0,0,0.55))",
-          }}
+          style={{ background: "linear-gradient(to bottom, transparent 30%, rgba(0,0,0,0.55))" }}
         />
 
-        {/* Floating back & share buttons */}
-        <div className="absolute top-0 left-0 right-0 flex items-center justify-between px-5 pt-2 z-10">
+        {/* Floating back, save & share buttons */}
+        <div className="absolute top-0 left-0 right-0 flex items-center justify-between pt-2 z-10" style={{ paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding }}>
           <button
             onClick={onBack}
-            className="w-[40px] h-[40px] rounded-full flex items-center justify-center active:scale-95 transition-transform"
-            style={{
-              backgroundColor: "rgba(255,255,255,0.9)",
-              boxShadow: "0 1px 3px rgba(0,0,0,0.04)",
-            }}
+            className="flex items-center justify-center rounded-full active:scale-95 transition-transform"
+            style={{ width: 40, height: 40, backgroundColor: "rgba(255,255,255,0.9)", boxShadow: Shadows.sm }}
           >
-            <ArrowLeft size={22} style={{ color: BRAND.textPrimary }} />
+            <ArrowLeft size={22} style={{ color: Neutral[800] }} />
           </button>
-          <button
-            className="w-[40px] h-[40px] rounded-full flex items-center justify-center active:scale-95 transition-transform"
-            style={{
-              backgroundColor: "rgba(255,255,255,0.9)",
-              boxShadow: "0 1px 3px rgba(0,0,0,0.04)",
-            }}
-          >
-            <Share2 size={20} style={{ color: BRAND.textPrimary }} />
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              className="flex items-center justify-center rounded-full active:scale-95 transition-transform"
+              style={{ width: 40, height: 40, backgroundColor: "rgba(255,255,255,0.9)", boxShadow: Shadows.sm }}
+            >
+              <Heart size={20} style={{ color: Neutral[800] }} />
+            </button>
+            <button
+              className="flex items-center justify-center rounded-full active:scale-95 transition-transform"
+              style={{ width: 40, height: 40, backgroundColor: "rgba(255,255,255,0.9)", boxShadow: Shadows.sm }}
+            >
+              <Share2 size={20} style={{ color: Neutral[800] }} />
+            </button>
+          </div>
         </div>
 
-        {/* Hero tag pills — positioned at bottom-left of hero */}
-        {event.tags && event.tags.length > 0 && (
-          <div className="absolute bottom-8 left-5 flex flex-wrap gap-1.5 z-10">
-            {event.tags.map((tag) => (
-              <span
-                key={tag.code}
-                className="px-2.5 py-1 rounded-full text-[12px] font-semibold"
-                style={{
-                  backgroundColor: "rgba(255,255,255,0.85)",
-                  color: BRAND.textPrimary,
-                }}
-              >
-                {tag.name}
-              </span>
-            ))}
-          </div>
-        )}
+        {/* Category labels at bottom-left of hero */}
+        <div className="absolute bottom-8 left-5 flex flex-wrap gap-1.5 z-10">
+          {event.categories?.map((cat) => (
+            <span
+              key={cat.code}
+              style={{ fontSize: Typography.meta.size, fontWeight: 600, color: "#FFFFFF", textShadow: "0 1px 4px rgba(0,0,0,0.4)" }}
+            >
+              {cat.name}
+            </span>
+          ))}
+        </div>
       </div>
 
-      {/* Content sheet — overlaps hero by -20px, rounded yellow corners */}
+      {/* Content sheet — overlaps hero, rounded top (Radii.sheet = 24) */}
       <div
         className="relative flex-1"
         style={{
-          backgroundColor: BRAND.surface,
-          borderTopLeftRadius: "24px",
-          borderTopRightRadius: "24px",
-          marginTop: "-20px",
-          paddingBottom: hasCta ? "80px" : "20px",
+          backgroundColor: Surface.surface,
+          borderTopLeftRadius: Radii.sheet,
+          borderTopRightRadius: Radii.sheet,
+          marginTop: -20,
+          paddingBottom: hasCta ? 80 : 20,
         }}
       >
-        <div className="px-5 pt-6">
+        <div style={{ paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding, paddingTop: Spacing.lg }}>
           {/* Title */}
           <h1
-            className="text-[24px] font-bold leading-snug break-words mb-1"
-            style={{ color: BRAND.textPrimary }}
+            className="break-words mb-1"
+            style={{
+              fontSize: 24,
+              fontWeight: 700,
+              lineHeight: "30px",
+              color: Neutral[800],
+            }}
           >
             {event.title}
           </h1>
 
           {/* Category meta */}
-          <p className="text-[13px] mb-1" style={{ color: BRAND.textSecondary }}>
+          <p className="mb-1" style={{ fontSize: Typography.meta.size, color: Neutral[500] }}>
             {CATEGORY_SHORT_LABELS[categoryCode]}
             {event.subcategories?.[0] && ` · ${event.subcategories[0].name}`}
           </p>
 
           {/* Date */}
           {dateLabel && (
-            <p
-              className="text-[16px] font-semibold mb-6"
-              style={{ color: BRAND.textPrimary }}
-            >
+            <p className="mb-6" style={{ fontSize: Typography.cardTitle.size, fontWeight: 600, color: Neutral[800] }}>
               {dateLabel}
               {timeLabel && (
-                <span style={{ color: BRAND.textSecondary, fontWeight: 400 }}>
-                  {" "}
-                  kl. {timeLabel}
-                </span>
+                <span style={{ color: Neutral[500], fontWeight: 400 }}> kl. {timeLabel}</span>
               )}
             </p>
           )}
 
-          {/* Category & subcategory pills */}
-          {(event.categories?.length > 0 || event.subcategories?.length > 0) && (
-            <div className="flex flex-wrap gap-1.5 mb-6">
-              {event.categories?.map((cat) => (
-                <span
-                  key={cat.code}
-                  className="text-[10px] font-bold uppercase tracking-wide px-2.5 py-1 rounded-full"
-                  style={{ backgroundColor: tint, color }}
-                >
-                  {cat.name}
-                </span>
-              ))}
-              {event.subcategories?.map((sub) => (
-                <span
-                  key={sub.code}
-                  className="text-[10px] font-medium px-2.5 py-1 rounded-full border"
-                  style={{ borderColor: BRAND.border, color: BRAND.textSecondary }}
-                >
-                  {sub.name}
-                </span>
-              ))}
-            </div>
-          )}
 
           {/* About section */}
           {event.description && (
             <div className="mb-6">
-              <h2
-                className="text-[20px] font-semibold mb-2"
-                style={{ color: BRAND.textPrimary }}
-              >
+              <h2 className="mb-2" style={{ fontSize: Typography.sectionTitle.size, fontWeight: Typography.sectionTitle.weight, color: Neutral[800] }}>
                 Om evenemanget
               </h2>
-              <p
-                className="text-[15px] leading-relaxed break-words"
-                style={{ color: BRAND.textBody }}
-              >
+              <p className="break-words" style={{ fontSize: Typography.body.size, lineHeight: `${Typography.body.lineHeight}px`, color: Neutral[700] }}>
                 {event.description}
               </p>
             </div>
@@ -230,22 +201,17 @@ export function EventDetailScreen({ eventId, onBack }: EventDetailScreenProps) {
           {/* Organiser section */}
           {event.organiser && (
             <div className="mb-6">
-              <p
-                className="text-[11px] font-bold uppercase tracking-wider mb-1"
-                style={{ color: BRAND.textSecondary }}
-              >
+              <p className="uppercase tracking-wider mb-1" style={{ fontSize: 11, fontWeight: 700, color: Neutral[500] }}>
                 Arrangör
               </p>
               <div className="flex items-center gap-2">
                 <div
-                  className="w-[28px] h-[28px] rounded-full flex items-center justify-center"
-                  style={{ backgroundColor: BRAND.neutral100 }}
+                  className="flex items-center justify-center rounded-full"
+                  style={{ width: 28, height: 28, backgroundColor: Neutral[100] }}
                 >
-                  <User size={14} style={{ color: BRAND.textSecondary }} />
+                  <User size={14} style={{ color: Neutral[500] }} />
                 </div>
-                <p className="text-[15px]" style={{ color: BRAND.textBody }}>
-                  {event.organiser}
-                </p>
+                <p style={{ fontSize: Typography.body.size, color: Neutral[700] }}>{event.organiser}</p>
               </div>
             </div>
           )}
@@ -253,22 +219,17 @@ export function EventDetailScreen({ eventId, onBack }: EventDetailScreenProps) {
           {/* Location section */}
           {fullAddress && (
             <div className="mb-6">
-              <p
-                className="text-[11px] font-bold uppercase tracking-wider mb-1"
-                style={{ color: BRAND.textSecondary }}
-              >
+              <p className="uppercase tracking-wider mb-1" style={{ fontSize: 11, fontWeight: 700, color: Neutral[500] }}>
                 Plats
               </p>
               <div className="flex items-center gap-2">
                 <div
-                  className="w-[28px] h-[28px] rounded-full flex items-center justify-center"
-                  style={{ backgroundColor: BRAND.neutral100 }}
+                  className="flex items-center justify-center rounded-full"
+                  style={{ width: 28, height: 28, backgroundColor: Neutral[100] }}
                 >
-                  <MapPin size={14} style={{ color: BRAND.textSecondary }} />
+                  <MapPin size={14} style={{ color: Neutral[500] }} />
                 </div>
-                <p className="text-[15px] break-words" style={{ color: BRAND.textBody }}>
-                  {fullAddress}
-                </p>
+                <p className="break-words" style={{ fontSize: Typography.body.size, color: Neutral[700] }}>{fullAddress}</p>
               </div>
             </div>
           )}
@@ -276,24 +237,21 @@ export function EventDetailScreen({ eventId, onBack }: EventDetailScreenProps) {
           {/* Schedule section */}
           {event.hasSchedule && event.scheduleStartTime && (
             <div className="mb-6">
-              <p
-                className="text-[11px] font-bold uppercase tracking-wider mb-1"
-                style={{ color: BRAND.textSecondary }}
-              >
+              <p className="uppercase tracking-wider mb-1" style={{ fontSize: 11, fontWeight: 700, color: Neutral[500] }}>
                 Tider
               </p>
               <div className="flex items-center gap-2">
                 <div
-                  className="w-[28px] h-[28px] rounded-full flex items-center justify-center"
-                  style={{ backgroundColor: BRAND.neutral100 }}
+                  className="flex items-center justify-center rounded-full"
+                  style={{ width: 28, height: 28, backgroundColor: Neutral[100] }}
                 >
-                  <Clock size={14} style={{ color: BRAND.textSecondary }} />
+                  <Clock size={14} style={{ color: Neutral[500] }} />
                 </div>
-                <p className="text-[15px]" style={{ color: BRAND.textBody }}>
+                <p style={{ fontSize: Typography.body.size, color: Neutral[700] }}>
                   {event.scheduleStartTime.substring(0, 5)}
                   {event.scheduleEndTime && ` – ${event.scheduleEndTime.substring(0, 5)}`}
                   {event.recurrence && (
-                    <span style={{ color: BRAND.textSecondary }}> ({event.recurrence})</span>
+                    <span style={{ color: Neutral[500] }}> ({event.recurrence})</span>
                   )}
                 </p>
               </div>
@@ -301,35 +259,38 @@ export function EventDetailScreen({ eventId, onBack }: EventDetailScreenProps) {
           )}
 
           {/* Source attribution */}
-          <div
-            className="pt-3 mt-2"
-            style={{ borderTop: `1px solid ${BRAND.neutral200}` }}
-          >
-            <p className="text-[13px]" style={{ color: BRAND.textSecondary }}>
+          <div className="pt-3 mt-2" style={{ borderTop: `1px solid ${Neutral[200]}` }}>
+            <p style={{ fontSize: Typography.meta.size, color: Neutral[500] }}>
               Källa:{" "}
-              {event.sourceProvider === "helsingborg"
-                ? "Helsingborg Events API"
-                : "Go.Do"}
+              {event.sourceProvider === "helsingborg" ? "Helsingborg Events API" : "Go.Do"}
             </p>
           </div>
         </div>
       </div>
 
-      {/* Sticky CTA bar */}
+      {/* Sticky CTA bar — matches GodoButton primary */}
       {hasCta && (
         <div
-          className="absolute bottom-0 left-0 right-0 px-5 py-3 pb-5 z-20"
+          className="absolute bottom-0 left-0 right-0 z-20"
           style={{
-            backgroundColor: BRAND.surface,
+            paddingLeft: Spacing.screenPadding,
+            paddingRight: Spacing.screenPadding,
+            paddingTop: 12,
+            paddingBottom: Spacing.screenPadding,
+            backgroundColor: Surface.surface,
             boxShadow: "0 -4px 16px rgba(0,0,0,0.08)",
           }}
         >
           <button
-            className="w-full flex items-center justify-center gap-2 py-3.5 rounded-[26px] text-[16px] font-semibold transition-all active:scale-[0.98] active:opacity-85"
+            className="w-full flex items-center justify-center gap-2 transition-all active:scale-[0.98] active:opacity-85"
             style={{
-              backgroundColor: BRAND.yellow,
-              color: BRAND.onPrimary,
-              minHeight: "48px",
+              minHeight: 48,
+              borderRadius: Radii.button,
+              backgroundColor: GodoYellow[500],
+              color: Surface.onPrimary,
+              fontSize: Typography.button.size,
+              fontWeight: Typography.button.weight,
+              fontFamily: FontFamily.body,
             }}
           >
             {event.bookingUrl && <ExternalLink size={16} />}

--- a/src/components/preview/screens/HomeScreen.tsx
+++ b/src/components/preview/screens/HomeScreen.tsx
@@ -1,30 +1,118 @@
 "use client";
 
-import { useMemo } from "react";
-import { categoryOptions, filterOptions } from "@/lib/content/contentText";
-import { EventDto } from "@/types/events";
+import { useState, useMemo } from "react";
 import {
   BRAND,
   CATEGORY_COLORS,
-  CATEGORY_TINTS,
   CATEGORY_SHORT_LABELS,
-  CATEGORY_GRADIENTS,
+  FontFamily,
+  Typography,
+  Spacing,
+  Radii,
+  Shadows,
+  Neutral,
+  GodoYellow,
+  Surface,
 } from "../constants";
-import { filterMockEvents } from "../mockEvents";
 import {
-  MapPin,
-  CalendarDays,
-  Bell,
   Search,
   Check,
-  ChevronDown,
+  ChevronRight,
+  Grid3X3,
+  CalendarRange,
+  CalendarDays,
+  Dribbble,
+  Film,
+  Landmark,
+  Mountain,
+  BookOpen,
+  HeartPulse,
+  Smile,
+  X,
+  Globe,
+  ChevronLeft,
 } from "lucide-react";
-import { format } from "date-fns";
-import { sv } from "date-fns/locale";
+import { MOCK_EVENTS } from "../mockEvents";
+
+// Category icon mapping matching the Expo app's Ionicons
+const CATEGORY_ICONS: Record<number, React.ElementType> = {
+  1: CalendarDays,
+  2: Dribbble,
+  3: Film,
+  4: Landmark,
+  5: Mountain,
+  6: BookOpen,
+  7: HeartPulse,
+  8: Smile,
+};
+
+// Subcategories matching backend DataSeeder
+const SUBCATEGORIES: Record<number, { code: number; label: string }[]> = {
+  1: [
+    { code: 101, label: "Festivaler & nöjen" },
+    { code: 102, label: "Fritid & livsstil" },
+    { code: 103, label: "Mässor & marknader" },
+  ],
+  2: [
+    { code: 201, label: "Sport att utöva" },
+    { code: 202, label: "Sport att titta på" },
+    { code: 203, label: "Sport att prova" },
+  ],
+  3: [
+    { code: 301, label: "Bio & film" },
+    { code: 302, label: "Musik & konserter" },
+    { code: 303, label: "Teater & shower" },
+  ],
+  4: [
+    { code: 401, label: "Guidade turer" },
+    { code: 402, label: "Konst & gallerier" },
+    { code: 403, label: "Museer & sevärdheter" },
+  ],
+  5: [
+    { code: 501, label: "Parker & leder" },
+    { code: 502, label: "Mat & dryck" },
+    { code: 503, label: "Utflykter & äventyr" },
+  ],
+  6: [
+    { code: 601, label: "Föreläsningar" },
+    { code: 602, label: "Lär dig..." },
+    { code: 603, label: "Samlingar & möten" },
+  ],
+  7: [
+    { code: 701, label: "Spa & bad" },
+    { code: 702, label: "Stöd & samverkan" },
+    { code: 703, label: "Trosaktiviteter" },
+  ],
+  8: [
+    { code: 801, label: "0–4 år" },
+    { code: 802, label: "5–10 år" },
+    { code: 803, label: "11–15 år" },
+  ],
+};
+
+// Derive available cities from mock events — only show cities that have events
+const AVAILABLE_CITIES = Array.from(
+  new Set(MOCK_EVENTS.map((e) => e.city).filter(Boolean) as string[]),
+).sort((a, b) => a.localeCompare(b, "sv"));
+
+// Swedish month/day names
+const SV_MONTHS = ["Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September", "Oktober", "November", "December"];
+const SV_DAYS_SHORT = ["Mån", "Tis", "Ons", "Tors", "Fre", "Lör", "Sön"];
+
+// Family-friendly order: Kids first, then broad→niche
+const ALL_CATEGORIES = [8, 1, 3, 2, 5, 4, 6, 7];
 
 interface HomeScreenProps {
   tagCodes: number[];
   selectedCategories: number[];
+  searchText: string;
+  cities: string[];
+  startDate: string | null;
+  endDate: string | null;
+  onSearchChange: (text: string) => void;
+  onToggleCity: (city: string) => void;
+  onSetCities: (cities: string[]) => void;
+  onDateRange: (start: string | null, end: string | null) => void;
   onTagsChange: (tagCodes: number[]) => void;
   onToggleCategory: (code: number) => void;
   onGoDo: (categoryCodes: number[]) => void;
@@ -32,302 +120,820 @@ interface HomeScreenProps {
 }
 
 export function HomeScreen({
-  tagCodes,
   selectedCategories,
-  onTagsChange,
+  searchText,
+  cities,
+  startDate,
+  endDate,
+  onSearchChange,
+  onToggleCity,
+  onSetCities,
+  onDateRange,
   onToggleCategory,
   onGoDo,
-  onSelectEvent,
 }: HomeScreenProps) {
-  const { items: events, totalCount } = useMemo(
-    () =>
-      filterMockEvents({
-        categoryCodes: selectedCategories.length > 0 ? selectedCategories : undefined,
-        tagCodes: tagCodes.length > 0 ? tagCodes : undefined,
-        pageSize: 6,
-      }),
-    [tagCodes, selectedCategories],
-  );
+  const [expandedCategory, setExpandedCategory] = useState<number | null>(null);
+  const [selectedSubs, setSelectedSubs] = useState<Record<number, number[]>>({});
+  const [showAll, setShowAll] = useState(false);
+  const [showCityModal, setShowCityModal] = useState(false);
+  const [showCalendarModal, setShowCalendarModal] = useState(false);
+  const [citySearch, setCitySearch] = useState("");
 
-  const toggleTag = (code: number) => {
-    onTagsChange(
-      tagCodes.includes(code) ? tagCodes.filter((c) => c !== code) : [...tagCodes, code],
+  const maxReached = selectedCategories.length >= 3;
+
+  const handleCategoryPress = (code: number) => {
+    setExpandedCategory(expandedCategory === code ? null : code);
+  };
+
+  const handleSubPress = (catCode: number, subCode: number) => {
+    setSelectedSubs((prev) => {
+      const current = prev[catCode] ?? [];
+      const next = current.includes(subCode)
+        ? current.filter((c) => c !== subCode)
+        : [...current, subCode];
+      return { ...prev, [catCode]: next };
+    });
+    if (!selectedCategories.includes(catCode)) {
+      onToggleCategory(catCode);
+    }
+  };
+
+  const handleEverythingPress = (catCode: number) => {
+    if (!selectedCategories.includes(catCode)) {
+      onToggleCategory(catCode);
+    }
+  };
+
+  const isCategorySelected = (code: number) => selectedCategories.includes(code);
+
+  const row1 = ALL_CATEGORIES.slice(0, 4);
+  const row2 = ALL_CATEGORIES.slice(4);
+
+  // City display text
+  const displayCity = cities.length > 0
+    ? (cities.length <= 2 ? cities.join(", ") : `${cities.length} städer`)
+    : "Alla städer";
+
+  // Date display text
+  const formatDate = (iso: string) => {
+    const d = new Date(iso);
+    return d.toLocaleDateString("sv-SE", { day: "numeric", month: "short" });
+  };
+  const dateDisplayText = !startDate
+    ? "Välj datum"
+    : !endDate
+      ? formatDate(startDate)
+      : `${formatDate(startDate)} – ${formatDate(endDate)}`;
+
+  // Filtered cities for modal search
+  const filteredCities = useMemo(() => {
+    if (!citySearch.trim()) return AVAILABLE_CITIES;
+    const q = citySearch.trim().toLowerCase();
+    return AVAILABLE_CITIES.filter((c) => c.toLowerCase().includes(q));
+  }, [citySearch]);
+
+  const renderSubcategorySection = (rowCodes: number[]) => {
+    if (!expandedCategory || !rowCodes.includes(expandedCategory)) return null;
+    const subs = SUBCATEGORIES[expandedCategory] ?? [];
+    const darkColor = CATEGORY_COLORS[expandedCategory] ?? "#374151";
+    const isSelected = isCategorySelected(expandedCategory);
+    const chipDisabled = maxReached && !isSelected;
+
+    return (
+      <div
+        className="w-full mb-2 transition-all"
+        style={{ animation: "fadeIn 0.2s ease", paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding }}
+      >
+        <div className="flex justify-center mb-0">
+          <div
+            className="w-0 h-0"
+            style={{
+              borderLeft: "8px solid transparent",
+              borderRight: "8px solid transparent",
+              borderBottom: `8px solid ${darkColor}33`,
+            }}
+          />
+        </div>
+        <div
+          className="flex flex-wrap py-2.5 pl-2.5"
+          style={{ borderLeft: `3px solid ${darkColor}44`, gap: `${Spacing.sm}px` }}
+        >
+          {subs.map((sub) => {
+            const active = (selectedSubs[expandedCategory] ?? []).includes(sub.code);
+            return (
+              <button
+                key={sub.code}
+                onClick={() => handleSubPress(expandedCategory, sub.code)}
+                className="px-3.5 transition-colors"
+                style={{
+                  height: 36,
+                  borderRadius: Radii.pill,
+                  backgroundColor: active ? darkColor : Surface.elevated,
+                  color: active ? "#FFFFFF" : darkColor,
+                  border: active ? "none" : `1.5px solid ${darkColor}`,
+                  opacity: chipDisabled && !active ? 0.4 : 1,
+                  fontFamily: FontFamily.body,
+                  fontSize: Typography.meta.size + 1,
+                  fontWeight: 500,
+                }}
+                disabled={chipDisabled && !active}
+              >
+                {sub.label}
+              </button>
+            );
+          })}
+          <button
+            onClick={() => handleEverythingPress(expandedCategory)}
+            className="px-3.5 transition-colors"
+            style={{
+              height: 36,
+              borderRadius: Radii.pill,
+              backgroundColor: isCategorySelected(expandedCategory) ? darkColor : Surface.elevated,
+              color: isCategorySelected(expandedCategory) ? "#FFFFFF" : darkColor,
+              border: isCategorySelected(expandedCategory) ? "none" : `1.5px solid ${darkColor}`,
+              opacity: chipDisabled && !isCategorySelected(expandedCategory) ? 0.4 : 1,
+              fontFamily: FontFamily.body,
+              fontSize: Typography.meta.size + 1,
+              fontWeight: 600,
+            }}
+          >
+            Allt
+          </button>
+        </div>
+      </div>
     );
   };
 
   return (
-    <div className="pb-4">
-      {/* Location header */}
-      <div className="flex items-center justify-between px-5 pt-1 pb-2">
-        <button
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium"
-          style={{ backgroundColor: BRAND.neutral100, color: BRAND.textBody }}
+    <div className="pb-4 relative" style={{ backgroundColor: Surface.background }}>
+      {/* Header — matches Expo Header component */}
+      <div className="flex items-center justify-between pt-1 pb-2" style={{ paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding }}>
+        <span
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            fontFamily: FontFamily.brand,
+            color: Neutral[800],
+            letterSpacing: 0.5,
+          }}
         >
-          <MapPin size={13} />
-          Helsingborg
-          <ChevronDown size={12} />
-        </button>
-        <button
-          className="w-[36px] h-[36px] flex items-center justify-center rounded-full"
-          style={{ backgroundColor: BRAND.neutral100 }}
-        >
-          <Bell size={16} style={{ color: BRAND.textBody }} />
-        </button>
+          Go.Do.
+        </span>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center" style={{ gap: 4 }}>
+            <button
+              className="flex items-center justify-center"
+              style={{ width: 48, height: 48, borderRadius: Radii.pill, fontSize: 22, opacity: 1 }}
+              aria-label="Svenska"
+            >
+              🇸🇪
+            </button>
+            <button
+              className="flex items-center justify-center"
+              style={{ width: 48, height: 48, borderRadius: Radii.pill, fontSize: 22, opacity: 0.4 }}
+              aria-label="English"
+            >
+              🇬🇧
+            </button>
+          </div>
+          <button
+            className="flex items-center justify-center rounded-full"
+            style={{ width: 36, height: 36, backgroundColor: "transparent" }}
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={Neutral[800]} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+              <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+            </svg>
+          </button>
+        </div>
       </div>
 
-      {/* Greeting */}
-      <div className="px-5 pb-3">
+      {/* Greeting — matches Expo: fontSize 20, weight 400, Neutral[700] */}
+      <div style={{ paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding, marginTop: 12, marginBottom: Spacing.screenPadding }}>
         <h1
-          className="text-[22px] font-bold leading-tight tracking-wide"
-          style={{ color: BRAND.textPrimary, letterSpacing: "0.25px" }}
+          style={{
+            fontSize: Typography.sectionTitle.size,
+            fontWeight: Typography.body.weight,
+            lineHeight: `28px`,
+            color: Neutral[700],
+            fontFamily: FontFamily.body,
+          }}
         >
-          Hej! Vad letar du efter idag?
+          Vad vill du göra?
         </h1>
       </div>
 
-      {/* Search bar */}
-      <div className="px-5 pb-3">
+      {/* Search bar — matches Expo: h48, Radii.input (12), Neutral[100] bg */}
+      <div style={{ paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding, marginBottom: Spacing.screenPadding }}>
         <div
-          className="flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl"
-          style={{ backgroundColor: BRAND.neutral100 }}
-        >
-          <Search size={16} style={{ color: BRAND.textSecondary }} />
-          <span className="text-[13px]" style={{ color: BRAND.textSecondary }}>
-            Sök evenemang...
-          </span>
-        </div>
-      </div>
-
-      {/* Date pill */}
-      <div className="px-5 pb-3">
-        <button
-          className="flex items-center gap-2 px-4 py-2 rounded-full text-[12px] font-semibold border-2"
+          className="flex items-center"
           style={{
-            borderColor: BRAND.yellow,
-            backgroundColor: BRAND.yellowLight,
-            color: BRAND.onPrimary,
+            height: 48,
+            backgroundColor: Neutral[100],
+            borderRadius: Radii.input,
+            paddingLeft: 14,
+            paddingRight: 14,
+            gap: 10,
           }}
         >
-          <CalendarDays size={14} />
-          Välj datum
-        </button>
-      </div>
-
-      {/* Category tiles — horizontal scroll */}
-      <div className="mb-3">
-        <div className="flex gap-2.5 overflow-x-auto pb-2 px-5 scrollbar-hide">
-          {categoryOptions.map((cat) => {
-            const Icon = cat.icon;
-            const code = cat.code;
-            const isSelected = selectedCategories.includes(code);
-            const color = CATEGORY_COLORS[code];
-            const tint = CATEGORY_TINTS[code];
-            return (
-              <button
-                key={code}
-                onClick={() => onToggleCategory(code)}
-                className="relative flex-shrink-0 flex flex-col items-center justify-center rounded-2xl w-[80px] h-[90px] transition-all active:scale-95"
-                style={{
-                  backgroundColor: isSelected ? color : tint,
-                  border: isSelected ? `2px solid ${BRAND.yellow}` : `1px solid ${color}15`,
-                  boxShadow: isSelected
-                    ? `0 2px 8px ${color}40`
-                    : "0 1px 3px rgba(0,0,0,0.04)",
-                }}
-              >
-                {isSelected && (
-                  <div
-                    className="absolute top-1.5 right-1.5 w-[16px] h-[16px] rounded-full flex items-center justify-center"
-                    style={{ backgroundColor: BRAND.yellow }}
-                  >
-                    <Check size={10} strokeWidth={3} style={{ color: BRAND.onPrimary }} />
-                  </div>
-                )}
-                <Icon size={22} color={isSelected ? "#fff" : color} strokeWidth={2} />
-                <span
-                  className="text-[10px] font-semibold mt-1.5 leading-tight text-center"
-                  style={{ color: isSelected ? "#fff" : color }}
-                >
-                  {CATEGORY_SHORT_LABELS[code]}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* Tag filter chips */}
-      <div className="flex gap-1.5 flex-wrap px-5 mb-3">
-        {filterOptions.map((tag) => {
-          const active = tagCodes.includes(tag.code);
-          return (
-            <button
-              key={tag.code}
-              onClick={() => toggleTag(tag.code)}
-              className="flex-shrink-0 px-3 py-1.5 rounded-full text-[11px] font-medium transition-colors"
-              style={{
-                backgroundColor: active ? BRAND.yellow : BRAND.neutral100,
-                color: active ? BRAND.onPrimary : BRAND.textSecondary,
-              }}
-            >
-              {tag.label}
-            </button>
-          );
-        })}
-      </div>
-
-      {/* Go.Do! button */}
-      <div className="px-5 mb-4">
-        <button
-          onClick={() => onGoDo(selectedCategories.length > 0 ? selectedCategories : [1])}
-          className="w-full py-3.5 rounded-[26px] text-[16px] font-bold tracking-wide transition-all active:scale-[0.97]"
-          style={{
-            backgroundColor: BRAND.yellow,
-            color: BRAND.onPrimary,
-            boxShadow: "0 4px 12px rgba(243, 193, 14, 0.4)",
-            letterSpacing: "0.5px",
-          }}
-        >
-          Go.Do!
-        </button>
-      </div>
-
-      {/* Upcoming section */}
-      <div className="px-5 mb-2.5">
-        <div className="flex items-center justify-between">
-          <h2
-            className="text-[16px] font-bold"
-            style={{ color: BRAND.textPrimary, letterSpacing: "0.25px" }}
-          >
-            Kommande evenemang
-          </h2>
-          <span className="text-[11px] font-medium" style={{ color: BRAND.textSecondary }}>
-            {totalCount} totalt
-          </span>
-        </div>
-      </div>
-
-      {/* Horizontal event cards */}
-      <div className="flex gap-3 overflow-x-auto px-5 pb-3 scrollbar-hide">
-        {events.slice(0, 5).map((event) => (
-          <UpcomingCard
-            key={event.id}
-            event={event}
-            onClick={() => onSelectEvent(event.id, event.categories?.[0]?.code ?? 1)}
+          <Search size={20} style={{ color: Neutral[500], flexShrink: 0 }} />
+          <input
+            type="text"
+            value={searchText}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Sök evenemang..."
+            className="flex-1 bg-transparent outline-none"
+            style={{
+              color: Neutral[800],
+              fontFamily: FontFamily.body,
+              fontSize: Typography.body.size,
+            }}
           />
-        ))}
+          {searchText && (
+            <button onClick={() => onSearchChange("")} className="flex-shrink-0">
+              <X size={16} style={{ color: Neutral[500] }} />
+            </button>
+          )}
+        </div>
       </div>
 
-      {/* Featured carousel placeholder */}
-      {events.length > 0 && (
-        <div className="px-5 mb-2">
-          <FeaturedCard event={events[0]} onClick={() => onSelectEvent(events[0].id, events[0].categories?.[0]?.code ?? 1)} />
+      {/* Max categories hint */}
+      {maxReached && (
+        <div className="flex items-center gap-1 mb-1" style={{ paddingLeft: Spacing.lg, paddingRight: Spacing.lg }}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={Neutral[500]} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 16v-4" />
+            <path d="M12 8h.01" />
+          </svg>
+          <span style={{ fontSize: Typography.caption.size, color: Neutral[500], fontFamily: FontFamily.body }}>
+            Max 3 kategorier valda
+          </span>
         </div>
       )}
 
-      {events.length === 0 && (
-        <p className="text-center text-[12px] py-6" style={{ color: BRAND.textSecondary }}>
-          Inga evenemang hittades
-        </p>
+      {/* Category grid — Row 1 */}
+      <div className="flex justify-center" style={{ paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding, gap: Spacing.sm, marginBottom: Spacing.sm }}>
+        {row1.map((code) => (
+          <CategoryTile
+            key={code}
+            code={code}
+            selected={isCategorySelected(code)}
+            disabled={maxReached && !isCategorySelected(code)}
+            onPress={() => handleCategoryPress(code)}
+          />
+        ))}
+      </div>
+      {renderSubcategorySection(row1)}
+
+      {/* Category grid — Row 2 */}
+      <div className="flex justify-center" style={{ paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding, gap: Spacing.sm, marginBottom: Spacing.sm }}>
+        {row2.map((code) => (
+          <CategoryTile
+            key={code}
+            code={code}
+            selected={isCategorySelected(code)}
+            disabled={maxReached && !isCategorySelected(code)}
+            onPress={() => handleCategoryPress(code)}
+          />
+        ))}
+      </div>
+      {renderSubcategorySection(row2)}
+
+      {/* Show All tile */}
+      <div className="flex justify-center" style={{ paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding, marginBottom: Spacing.sm }}>
+        <button
+          onClick={() => setShowAll(!showAll)}
+          className="relative flex flex-col items-center justify-center transition-all active:scale-95"
+          style={{
+            width: "23%",
+            aspectRatio: "0.88",
+            borderRadius: Radii.card,
+            backgroundColor: showAll ? Neutral[800] : Surface.elevated,
+            border: showAll ? `2px solid ${Neutral[700]}` : `1px solid ${Neutral[200]}`,
+            boxShadow: Shadows.sm,
+            gap: 6,
+          }}
+        >
+          {showAll && (
+            <div
+              className="absolute flex items-center justify-center"
+              style={{
+                top: 6, right: 6, width: 18, height: 18,
+                borderRadius: 9, backgroundColor: GodoYellow[500],
+              }}
+            >
+              <Check size={10} strokeWidth={3} style={{ color: Surface.onPrimary }} />
+            </div>
+          )}
+          <Grid3X3 size={28} color={showAll ? "#FFFFFF" : Neutral[800]} strokeWidth={2} />
+          <span
+            className="text-center px-1"
+            style={{
+              fontSize: 11, fontWeight: 600,
+              color: showAll ? "#FFFFFF" : Neutral[800],
+              fontFamily: FontFamily.body,
+            }}
+          >
+            Visa allt
+          </span>
+        </button>
+      </div>
+
+      {/* City picker row — opens modal */}
+      <div style={{ paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding, marginBottom: Spacing.sm }}>
+        <button
+          onClick={() => setShowCityModal(true)}
+          className="w-full flex items-center gap-2"
+          style={{
+            height: 52,
+            borderRadius: Radii.pill,
+            paddingLeft: 14,
+            paddingRight: 14,
+            backgroundColor: Neutral[100],
+          }}
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={Neutral[800]} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+            <circle cx="12" cy="10" r="3" />
+          </svg>
+          <span className="flex-1 text-left truncate" style={{ fontSize: Typography.cardTitle.size, fontWeight: 500, color: Neutral[700], fontFamily: FontFamily.body }}>
+            {displayCity}
+          </span>
+          <ChevronRight size={16} style={{ color: Neutral[400] }} />
+        </button>
+      </div>
+
+      {/* Date picker row — opens calendar modal */}
+      <div style={{ paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding, marginBottom: Spacing.screenPadding }}>
+        <button
+          onClick={() => setShowCalendarModal(true)}
+          className="w-full flex items-center gap-2 border"
+          style={{
+            height: 52,
+            borderRadius: Radii.pill,
+            paddingLeft: 14,
+            paddingRight: 14,
+            backgroundColor: GodoYellow[50],
+            borderColor: GodoYellow[200],
+          }}
+        >
+          <CalendarRange size={20} style={{ color: Neutral[800] }} />
+          <span className="flex-1 text-left truncate" style={{ fontSize: Typography.cardTitle.size, fontWeight: 500, color: Neutral[700], fontFamily: FontFamily.body }}>
+            {dateDisplayText}
+          </span>
+          {startDate && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDateRange(null, null);
+              }}
+              className="flex-shrink-0 mr-1"
+            >
+              <X size={14} style={{ color: Neutral[500] }} />
+            </button>
+          )}
+          <ChevronRight size={16} style={{ color: Neutral[400] }} />
+        </button>
+      </div>
+
+      {/* Go.Do. button — matches Expo: h48, Radii.button (26), Calibri-Bold, letterSpacing 1 */}
+      <div style={{ paddingLeft: Spacing.screenPadding, paddingRight: Spacing.screenPadding, marginBottom: Spacing.lg }}>
+        <button
+          onClick={() => onGoDo(selectedCategories.length > 0 ? selectedCategories : [1])}
+          className="w-full transition-all active:scale-[0.97] active:opacity-85"
+          style={{
+            height: 56,
+            borderRadius: Radii.button,
+            backgroundColor: "#000000",
+            color: "#FFFFFF",
+            fontFamily: FontFamily.brand,
+            fontSize: 22,
+            fontWeight: 700,
+            letterSpacing: 1,
+            boxShadow: Shadows.md,
+          }}
+        >
+          Go.Do.
+        </button>
+      </div>
+
+      {/* ── City selector modal ─────────────────────────────── */}
+      {showCityModal && (
+        <div
+          className="absolute inset-0 z-50 flex flex-col justify-end"
+          style={{ backgroundColor: "rgba(0,0,0,0.35)" }}
+          onClick={() => { setShowCityModal(false); setCitySearch(""); }}
+        >
+          <div
+            className="max-h-[80%] flex flex-col"
+            style={{ backgroundColor: Surface.surface, borderRadius: `${Radii.sheet}px ${Radii.sheet}px 0 0` }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Header */}
+            <div className="flex items-center p-4" style={{ borderBottom: `1px solid ${Neutral[200]}` }}>
+              <span className="flex-1" style={{ fontSize: Typography.sectionTitle.size, fontWeight: 700, color: Neutral[800], fontFamily: FontFamily.body }}>
+                Välj stad
+              </span>
+              {cities.length > 0 && (
+                <span
+                  className="mr-3 px-2 py-0.5"
+                  style={{ fontSize: Typography.caption.size, fontWeight: 700, borderRadius: Radii.pill, backgroundColor: Neutral[800], color: "#FFFFFF" }}
+                >
+                  {cities.length}
+                </span>
+              )}
+              <button
+                onClick={() => { setShowCityModal(false); setCitySearch(""); }}
+                className="flex items-center justify-center rounded-full"
+                style={{ width: 40, height: 40, backgroundColor: Neutral[800] }}
+              >
+                <X size={20} color="#FFFFFF" />
+              </button>
+            </div>
+
+            {/* Search */}
+            <div className="px-4 py-2">
+              <div
+                className="flex items-center border"
+                style={{
+                  height: 48,
+                  paddingLeft: 12,
+                  paddingRight: 12,
+                  gap: Spacing.sm,
+                  borderRadius: 10,
+                  backgroundColor: Surface.surface,
+                  borderColor: Neutral[300],
+                }}
+              >
+                <Search size={18} style={{ color: Neutral[500] }} />
+                <input
+                  type="text"
+                  value={citySearch}
+                  onChange={(e) => setCitySearch(e.target.value)}
+                  placeholder="Sök stad..."
+                  className="flex-1 bg-transparent outline-none"
+                  style={{ fontSize: Typography.cardTitle.size, color: Neutral[800], fontFamily: FontFamily.body }}
+                />
+                {citySearch && (
+                  <button onClick={() => setCitySearch("")}>
+                    <X size={16} style={{ color: Neutral[500] }} />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Selected city chips */}
+            {cities.length > 0 && (
+              <div className="flex flex-wrap px-4 pb-2" style={{ gap: 6 }}>
+                {cities.map((city) => (
+                  <button
+                    key={city}
+                    onClick={() => onToggleCity(city)}
+                    className="flex items-center gap-1 px-2.5 py-1"
+                    style={{ borderRadius: Radii.pill, fontSize: Typography.meta.size, fontWeight: 500, backgroundColor: Neutral[200], color: Neutral[800], fontFamily: FontFamily.body }}
+                  >
+                    {city}
+                    <X size={12} style={{ color: Neutral[700] }} />
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* "All cities" row */}
+            <button
+              onClick={() => { onSetCities([]); setCitySearch(""); setShowCityModal(false); }}
+              className="flex items-center mx-4 mb-1"
+              style={{
+                height: 48,
+                paddingLeft: 14,
+                paddingRight: 14,
+                gap: 10,
+                borderRadius: 10,
+                backgroundColor: cities.length === 0 ? Neutral[800] : Neutral[100],
+              }}
+            >
+              <Globe size={20} style={{ color: cities.length === 0 ? "#FFFFFF" : Neutral[500] }} />
+              <span
+                className="flex-1 text-left"
+                style={{
+                  fontSize: Typography.cardTitle.size,
+                  fontWeight: 500,
+                  color: cities.length === 0 ? "#FFFFFF" : Neutral[700],
+                  fontFamily: FontFamily.body,
+                }}
+              >
+                Alla städer
+              </span>
+              {cities.length === 0 && <Check size={18} color="#FFFFFF" />}
+            </button>
+
+            {/* City list */}
+            <div className="flex-1 overflow-y-auto scrollbar-hide">
+              {filteredCities.map((city) => {
+                const checked = cities.includes(city);
+                return (
+                  <button
+                    key={city}
+                    onClick={() => onToggleCity(city)}
+                    className="w-full flex items-center text-left"
+                    style={{
+                      height: 48,
+                      paddingLeft: Spacing.md,
+                      paddingRight: Spacing.md,
+                      backgroundColor: checked ? Neutral[800] : "transparent",
+                      borderBottom: `0.5px solid ${Neutral[200]}`,
+                    }}
+                  >
+                    <span
+                      className="flex items-center justify-center border mr-3"
+                      style={{
+                        width: 22, height: 22,
+                        borderRadius: 4,
+                        borderColor: checked ? "#FFFFFF" : Neutral[400],
+                        backgroundColor: checked ? Neutral[800] : "transparent",
+                      }}
+                    >
+                      {checked && <Check size={14} color="#FFFFFF" />}
+                    </span>
+                    <span
+                      className="flex-1"
+                      style={{
+                        fontSize: Typography.cardTitle.size,
+                        fontFamily: FontFamily.body,
+                        color: checked ? "#FFFFFF" : Neutral[800],
+                        fontWeight: checked ? 600 : 400,
+                      }}
+                    >
+                      {city}
+                    </span>
+                  </button>
+                );
+              })}
+              {filteredCities.length === 0 && (
+                <p className="text-center py-10" style={{ fontSize: Typography.cardTitle.size, color: Neutral[500], fontFamily: FontFamily.body }}>
+                  Inga städer hittades
+                </p>
+              )}
+            </div>
+
+            {/* Done button */}
+            <div className="px-4 py-2">
+              <button
+                onClick={() => { setShowCityModal(false); setCitySearch(""); }}
+                className="w-full"
+                style={{
+                  height: 48,
+                  borderRadius: Radii.input,
+                  backgroundColor: Neutral[800],
+                  color: "#FFFFFF",
+                  fontSize: Typography.button.size,
+                  fontWeight: Typography.button.weight,
+                  fontFamily: FontFamily.body,
+                }}
+              >
+                {cities.length > 0 ? `Klar (${cities.length})` : "Klar"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Calendar modal ──────────────────────────────────── */}
+      {showCalendarModal && (
+        <CalendarModal
+          startDate={startDate}
+          endDate={endDate}
+          onDateRange={onDateRange}
+          onClose={() => setShowCalendarModal(false)}
+        />
       )}
     </div>
   );
 }
 
-function UpcomingCard({ event, onClick }: { event: EventDto; onClick: () => void }) {
-  const catCode = event.categories?.[0]?.code ?? 1;
-  const gradient = CATEGORY_GRADIENTS[catCode] ?? CATEGORY_GRADIENTS[1];
-  const isFree = event.tags?.some((t) => t.code === 1001);
-  const dateLabel = event.startDate
-    ? format(new Date(event.startDate), "d MMM", { locale: sv })
-    : "";
+/* ── Category tile — matches Expo CategoryTile exactly ─────────── */
+function CategoryTile({
+  code,
+  selected,
+  disabled,
+  onPress,
+}: {
+  code: number;
+  selected: boolean;
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  const dark = CATEGORY_COLORS[code] ?? "#374151";
+  const Icon = CATEGORY_ICONS[code] ?? CalendarDays;
+  const bgColor = disabled && !selected ? Neutral[300] : dark;
 
   return (
     <button
-      onClick={onClick}
-      className="flex-shrink-0 w-[200px] rounded-[18px] overflow-hidden text-left transition-transform active:scale-[0.97]"
+      onClick={() => !disabled && onPress()}
+      className="relative flex flex-col items-center justify-center transition-all active:scale-95"
       style={{
-        backgroundColor: BRAND.surface,
-        boxShadow: "0 2px 8px rgba(0,0,0,0.06)",
+        width: "23%",
+        aspectRatio: "0.88",
+        borderRadius: Radii.card,
+        backgroundColor: bgColor,
+        border: selected ? `2px solid ${GodoYellow[500]}` : "none",
+        boxShadow: Shadows.sm,
+        opacity: disabled && !selected ? 0.7 : 1,
+        gap: 6,
       }}
     >
-      {/* Image placeholder with gradient */}
-      <div
-        className="relative h-[110px]"
-        style={{ background: `linear-gradient(135deg, ${gradient[0]}, ${gradient[1]})` }}
-      >
-        <div className="absolute inset-0 bg-black/10" />
-        {/* Date badge */}
-        {dateLabel && (
-          <span className="absolute top-2.5 left-2.5 px-2 py-0.5 rounded-full bg-white text-[10px] font-bold" style={{ color: BRAND.textPrimary }}>
-            {dateLabel}
-          </span>
-        )}
-        {/* Free badge */}
-        {isFree && (
-          <span
-            className="absolute bottom-2.5 left-2.5 px-2 py-0.5 rounded-full text-[9px] font-bold"
-            style={{ backgroundColor: BRAND.yellow, color: BRAND.onPrimary }}
-          >
-            Gratis
-          </span>
-        )}
-      </div>
-      <div className="p-3">
-        <h3
-          className="text-[13px] font-semibold leading-snug line-clamp-2 mb-1"
-          style={{ color: BRAND.textPrimary }}
+      {selected && (
+        <div
+          className="absolute flex items-center justify-center"
+          style={{
+            top: 6, right: 6, width: 18, height: 18,
+            borderRadius: 9, backgroundColor: GodoYellow[500],
+          }}
         >
-          {event.title}
-        </h3>
-        <span className="flex items-center gap-1 text-[11px]" style={{ color: BRAND.textSecondary }}>
-          <MapPin size={10} />
-          {event.city}
-        </span>
-      </div>
+          <Check size={12} strokeWidth={3} style={{ color: dark }} />
+        </div>
+      )}
+      <Icon size={28} color="#FFFFFF" strokeWidth={2} />
+      <span
+        className="text-center px-1 leading-tight"
+        style={{
+          fontSize: 11,
+          fontWeight: 600,
+          color: "#FFFFFF",
+          fontFamily: FontFamily.body,
+        }}
+      >
+        {CATEGORY_SHORT_LABELS[code]}
+      </span>
     </button>
   );
 }
 
-function FeaturedCard({ event, onClick }: { event: EventDto; onClick: () => void }) {
-  const catCode = event.categories?.[0]?.code ?? 1;
-  const gradient = CATEGORY_GRADIENTS[catCode] ?? CATEGORY_GRADIENTS[1];
-  const dateLabel = event.startDate
-    ? format(new Date(event.startDate), "d MMM yyyy", { locale: sv })
-    : "";
+/* ── Calendar modal (Swedish, range selection) ──────────────── */
+function CalendarModal({
+  startDate,
+  endDate,
+  onDateRange,
+  onClose,
+}: {
+  startDate: string | null;
+  endDate: string | null;
+  onDateRange: (start: string | null, end: string | null) => void;
+  onClose: () => void;
+}) {
+  const today = new Date();
+  const [viewYear, setViewYear] = useState(today.getFullYear());
+  const [viewMonth, setViewMonth] = useState(today.getMonth()); // 0-based
+
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+  // Monday=0 based first day offset
+  const firstDayOfWeek = (new Date(viewYear, viewMonth, 1).getDay() + 6) % 7;
+
+  const toIso = (day: number) => {
+    const m = String(viewMonth + 1).padStart(2, "0");
+    const d = String(day).padStart(2, "0");
+    return `${viewYear}-${m}-${d}`;
+  };
+
+  const handleDayClick = (day: number) => {
+    const date = toIso(day);
+    if (!startDate || (startDate && endDate)) {
+      onDateRange(date, null);
+    } else if (date < startDate) {
+      onDateRange(date, null);
+    } else if (date === startDate) {
+      onDateRange(startDate, null);
+    } else {
+      onDateRange(startDate, date);
+    }
+  };
+
+  const isInRange = (day: number) => {
+    if (!startDate) return false;
+    const iso = toIso(day);
+    if (!endDate) return iso === startDate;
+    return iso >= startDate && iso <= endDate;
+  };
+
+  const isStart = (day: number) => startDate === toIso(day);
+  const isEnd = (day: number) => endDate === toIso(day);
+
+  const prevMonth = () => {
+    if (viewMonth === 0) { setViewMonth(11); setViewYear(viewYear - 1); }
+    else { setViewMonth(viewMonth - 1); }
+  };
+
+  const nextMonth = () => {
+    if (viewMonth === 11) { setViewMonth(0); setViewYear(viewYear + 1); }
+    else { setViewMonth(viewMonth + 1); }
+  };
 
   return (
-    <button
-      onClick={onClick}
-      className="w-full text-left rounded-[18px] overflow-hidden transition-transform active:scale-[0.98]"
-      style={{
-        /* RGB animated border effect (static version for web) */
-        padding: "2.5px",
-        background: `linear-gradient(135deg, ${BRAND.yellow}, #F87171, #A78BFA, #60A5FA, #FB923C, #F472B6, ${BRAND.yellow})`,
-        backgroundSize: "400% 400%",
-        animation: "rgbShift 4s ease infinite",
-      }}
+    <div
+      className="absolute inset-0 z-50 flex flex-col justify-end"
+      style={{ backgroundColor: "rgba(0,0,0,0.35)" }}
+      onClick={onClose}
     >
       <div
-        className="relative h-[160px] rounded-[16px] overflow-hidden"
-        style={{ background: `linear-gradient(135deg, ${gradient[0]}, ${gradient[1]})` }}
+        className="p-4"
+        style={{
+          backgroundColor: Surface.surface,
+          borderRadius: `${Radii.sheet}px ${Radii.sheet}px 0 0`,
+          boxShadow: "0 -4px 16px rgba(0,0,0,0.08)",
+        }}
+        onClick={(e) => e.stopPropagation()}
       >
-        <div className="absolute inset-0 bg-black/20" />
-        <div className="absolute bottom-0 left-0 right-0 p-4">
-          {dateLabel && (
-            <span className="inline-block px-2.5 py-0.5 rounded-full bg-white text-[10px] font-bold mb-2" style={{ color: BRAND.textPrimary }}>
-              {dateLabel}
-            </span>
-          )}
-          <h3 className="text-[17px] font-bold text-white leading-snug" style={{ textShadow: "0 1px 4px rgba(0,0,0,0.3)" }}>
-            {event.title}
-          </h3>
-          <span className="flex items-center gap-1 text-[11px] text-white/80 mt-0.5">
-            <MapPin size={10} />
-            {event.city}
+        {/* Month navigation */}
+        <div className="flex items-center justify-between mb-3">
+          <button onClick={prevMonth} className="flex items-center justify-center" style={{ width: 36, height: 36 }}>
+            <ChevronLeft size={20} style={{ color: Neutral[800] }} />
+          </button>
+          <span style={{ fontSize: 22, fontWeight: 700, color: Neutral[800], fontFamily: FontFamily.body }}>
+            {SV_MONTHS[viewMonth]} {viewYear}
           </span>
+          <button onClick={nextMonth} className="flex items-center justify-center" style={{ width: 36, height: 36 }}>
+            <ChevronRight size={20} style={{ color: Neutral[800] }} />
+          </button>
         </div>
+
+        {/* Day headers */}
+        <div className="grid grid-cols-7 mb-1">
+          {SV_DAYS_SHORT.map((d) => (
+            <div key={d} className="text-center py-1" style={{ fontSize: 11, fontWeight: 700, color: Neutral[500], fontFamily: FontFamily.body }}>
+              {d}
+            </div>
+          ))}
+        </div>
+
+        {/* Day grid */}
+        <div className="grid grid-cols-7">
+          {Array.from({ length: firstDayOfWeek }).map((_, i) => (
+            <div key={`empty-${i}`} style={{ height: 36 }} />
+          ))}
+          {Array.from({ length: daysInMonth }).map((_, i) => {
+            const day = i + 1;
+            const inRange = isInRange(day);
+            const start = isStart(day);
+            const end = isEnd(day);
+            const todayStr = today.toISOString().slice(0, 10);
+            const isToday = toIso(day) === todayStr;
+
+            return (
+              <button
+                key={day}
+                onClick={() => handleDayClick(day)}
+                className="flex items-center justify-center transition-colors"
+                style={{
+                  height: 36,
+                  fontFamily: FontFamily.body,
+                  fontSize: Typography.meta.size + 1,
+                  fontWeight: 600,
+                  backgroundColor: start || end
+                    ? GodoYellow[500]
+                    : inRange
+                      ? GodoYellow[200]
+                      : "transparent",
+                  color: start || end
+                    ? Surface.onPrimary
+                    : inRange
+                      ? Neutral[800]
+                      : isToday
+                        ? Neutral[800]
+                        : Neutral[700],
+                  borderRadius: start
+                    ? "999px 0 0 999px"
+                    : end
+                      ? "0 999px 999px 0"
+                      : start && !endDate
+                        ? "999px"
+                        : "0",
+                  ...(start && !endDate ? { borderRadius: "999px" } : {}),
+                }}
+              >
+                {day}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Go.Set. button — matches Expo branded button: Calibri-Bold */}
+        <button
+          onClick={onClose}
+          className="w-full mt-4 active:opacity-85 active:scale-[0.98]"
+          style={{
+            height: 48,
+            borderRadius: Radii.button,
+            backgroundColor: GodoYellow[500],
+            color: Surface.onPrimary,
+            fontFamily: FontFamily.brand,
+            fontSize: 18,
+            fontWeight: 700,
+            letterSpacing: 0.5,
+          }}
+        >
+          Go.Set.
+        </button>
       </div>
-    </button>
+    </div>
   );
 }

--- a/src/components/preview/screens/ResultsScreen.tsx
+++ b/src/components/preview/screens/ResultsScreen.tsx
@@ -6,22 +6,31 @@ import { EventDto } from "@/types/events";
 import {
   BRAND,
   CATEGORY_COLORS,
-  CATEGORY_TINTS,
   CATEGORY_SHORT_LABELS,
   CATEGORY_EMOJIS,
   MOCK_LOCATIONS,
   HELSINGBORG_CENTER,
+  FontFamily,
+  Typography,
+  Spacing,
+  Radii,
+  Shadows,
+  Neutral,
+  GodoYellow,
+  Surface,
+  CoolPastels,
 } from "../constants";
-import { filterMockEvents } from "../mockEvents";
+import { filterMockEvents, SortMode } from "../mockEvents";
 import {
   ArrowLeft,
   MapPin,
   CalendarDays,
-  Navigation,
   ArrowUpDown,
   SlidersHorizontal,
   Map as MapIcon,
   List,
+  Heart,
+  Check,
 } from "lucide-react";
 import { format } from "date-fns";
 import { sv } from "date-fns/locale";
@@ -30,30 +39,43 @@ interface ResultsScreenProps {
   categoryCode: number;
   tagCodes: number[];
   showMap: boolean;
+  searchText?: string;
+  cities?: string[];
+  startDate?: string | null;
+  endDate?: string | null;
   onToggleMap: () => void;
   onTagsChange: (tagCodes: number[]) => void;
   onBack: () => void;
   onSelectEvent: (eventId: string) => void;
 }
 
+const SORT_OPTIONS: { mode: SortMode; label: string }[] = [
+  { mode: "date_asc", label: "Datum (närmast)" },
+  { mode: "date_desc", label: "Datum (längst bort)" },
+  { mode: "alpha_asc", label: "A–Ö" },
+];
+
 export function ResultsScreen({
   categoryCode,
   tagCodes,
   showMap,
+  searchText,
+  cities,
+  startDate,
+  endDate,
   onToggleMap,
   onTagsChange,
   onBack,
   onSelectEvent,
 }: ResultsScreenProps) {
   const [selectedSub, setSelectedSub] = useState<number | null>(null);
-  const [nearMe, setNearMe] = useState(false);
   const [showSort, setShowSort] = useState(false);
   const [showFilter, setShowFilter] = useState(false);
+  const [sortMode, setSortMode] = useState<SortMode>("date_asc");
 
   const category = categoryOptions.find((c) => c.code === categoryCode);
   const subcategories = subcategoriesMap[categoryCode] ?? [];
   const color = CATEGORY_COLORS[categoryCode] ?? CATEGORY_COLORS[1];
-  const tint = CATEGORY_TINTS[categoryCode] ?? CATEGORY_TINTS[1];
 
   const toggleTag = (code: number) => {
     onTagsChange(
@@ -61,131 +83,162 @@ export function ResultsScreen({
     );
   };
 
+  const handleSort = (mode: SortMode) => {
+    setSortMode(mode);
+    setShowSort(false);
+  };
+
+  // City display text
+  const cityDisplay = cities && cities.length > 0
+    ? (cities.length <= 2 ? cities.join(", ") : `${cities.length} städer`)
+    : "Alla städer";
+
+  // Date display text
+  const formatDateShort = (iso: string) => {
+    const d = new Date(iso);
+    return d.toLocaleDateString("sv-SE", { day: "numeric", month: "short" });
+  };
+  const dateDisplay = !startDate
+    ? "Välj datum"
+    : !endDate
+      ? formatDateShort(startDate)
+      : `${formatDateShort(startDate)} – ${formatDateShort(endDate)}`;
+
   const { items: events, totalCount } = useMemo(
     () =>
       filterMockEvents({
         categoryCodes: [categoryCode],
         subcategoryCodes: selectedSub ? [selectedSub] : undefined,
         tagCodes: tagCodes.length > 0 ? tagCodes : undefined,
-        pageSize: 15,
+        searchText: searchText || undefined,
+        cities: cities && cities.length > 0 ? cities : undefined,
+        startDate,
+        endDate,
+        sortMode,
+        pageSize: 30,
       }),
-    [categoryCode, selectedSub, tagCodes],
+    [categoryCode, selectedSub, tagCodes, searchText, cities, startDate, endDate, sortMode],
   );
 
   return (
-    <div style={{ backgroundColor: BRAND.background }}>
+    <div style={{ backgroundColor: Surface.surface, fontFamily: FontFamily.body }}>
       {/* Compact header */}
-      <div className="px-4 pt-1 pb-2" style={{ backgroundColor: BRAND.surface, borderBottom: `1px solid ${BRAND.border}` }}>
+      <div className="pt-1 pb-2" style={{ paddingLeft: Spacing.md, paddingRight: Spacing.md, backgroundColor: Surface.surface, borderBottom: `1px solid ${Neutral[200]}` }}>
         <div className="flex items-center gap-2 mb-1.5">
           <button
             onClick={onBack}
-            className="w-[34px] h-[34px] flex items-center justify-center rounded-full active:opacity-70"
-            style={{ backgroundColor: BRAND.neutral100 }}
+            className="flex items-center justify-center rounded-full active:opacity-70"
+            style={{ width: 36, height: 36, backgroundColor: Neutral[100] }}
           >
-            <ArrowLeft size={16} style={{ color: BRAND.textBody }} />
+            <ArrowLeft size={16} style={{ color: Neutral[700] }} />
           </button>
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1.5">
-              {category && <category.icon size={16} color={color} strokeWidth={2} />}
-              <h1 className="text-[15px] font-bold truncate" style={{ color: BRAND.textPrimary }}>
+            <div className="flex items-center gap-1 overflow-x-auto scrollbar-hide">
+              <span
+                className="flex-shrink-0 px-2 py-0.5"
+                style={{ borderRadius: Radii.pill, fontSize: Typography.caption.size - 2, fontWeight: 600, backgroundColor: color, color: "#FFFFFF" }}
+              >
                 {CATEGORY_SHORT_LABELS[categoryCode] ?? category?.label}
-              </h1>
+              </span>
+              {selectedSub && (
+                <span
+                  className="flex-shrink-0 px-2 py-0.5"
+                  style={{ borderRadius: Radii.pill, fontSize: Typography.caption.size - 2, fontWeight: 600, backgroundColor: GodoYellow[500], color: Surface.onPrimary }}
+                >
+                  {subcategories.find((s) => s.code === selectedSub)?.label}
+                </span>
+              )}
+              {tagCodes.slice(0, 2).map((tc) => {
+                const tag = filterOptions.find((f) => f.code === tc);
+                return (
+                  <span
+                    key={tc}
+                    className="flex-shrink-0 px-2 py-0.5"
+                    style={{ borderRadius: Radii.pill, fontSize: Typography.caption.size - 2, fontWeight: 600, backgroundColor: GodoYellow[500], color: Surface.onPrimary }}
+                  >
+                    {tag?.label}
+                  </span>
+                );
+              })}
+              {tagCodes.length > 2 && (
+                <span
+                  className="flex-shrink-0 px-1.5 py-0.5"
+                  style={{ borderRadius: Radii.pill, fontSize: Typography.caption.size - 2, fontWeight: 600, backgroundColor: Neutral[100], color: Neutral[500] }}
+                >
+                  +{tagCodes.length - 2}
+                </span>
+              )}
             </div>
           </div>
           <span
-            className="text-[11px] font-medium px-2 py-0.5 rounded-full"
-            style={{ backgroundColor: BRAND.neutral100, color: BRAND.textSecondary }}
+            className="px-2 py-0.5 flex-shrink-0"
+            style={{ fontSize: 11, fontWeight: 600, borderRadius: Radii.pill, backgroundColor: Neutral[100], color: Neutral[500] }}
           >
             {totalCount}
           </span>
         </div>
-
-        {/* Inline filter chips */}
-        {(selectedSub || tagCodes.length > 0) && (
-          <div className="flex gap-1 overflow-x-auto pb-1 scrollbar-hide">
-            {selectedSub && (
-              <span
-                className="flex-shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold"
-                style={{ backgroundColor: BRAND.yellow, color: BRAND.onPrimary }}
-              >
-                {subcategories.find((s) => s.code === selectedSub)?.label}
-              </span>
-            )}
-            {tagCodes.map((tc) => {
-              const tag = filterOptions.find((f) => f.code === tc);
-              return (
-                <span
-                  key={tc}
-                  className="flex-shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold"
-                  style={{ backgroundColor: BRAND.yellow, color: BRAND.onPrimary }}
-                >
-                  {tag?.label}
-                </span>
-              );
-            })}
-          </div>
-        )}
       </div>
 
-      {/* Toolbar */}
-      <div className="flex items-center gap-1.5 px-4 py-2" style={{ backgroundColor: BRAND.surface }}>
-        <ToolbarPill
-          active={nearMe}
-          onClick={() => setNearMe(!nearMe)}
-          icon={<Navigation size={13} />}
-          label="Nära mig"
-        />
-        <ToolbarPill
-          active={showSort}
-          onClick={() => { setShowSort(!showSort); setShowFilter(false); }}
-          icon={<ArrowUpDown size={13} />}
-          label="Sortera"
-        />
-        <ToolbarPill
-          active={showFilter}
-          onClick={() => { setShowFilter(!showFilter); setShowSort(false); }}
-          icon={<SlidersHorizontal size={13} />}
-          label="Filter"
-        />
-        <div className="flex-1" />
-        <button
-          onClick={onToggleMap}
-          className="w-[34px] h-[34px] flex items-center justify-center rounded-full transition-colors"
-          style={{
-            backgroundColor: showMap ? BRAND.yellow : BRAND.neutral100,
-            color: showMap ? BRAND.onPrimary : BRAND.textSecondary,
-          }}
-        >
-          {showMap ? <List size={15} /> : <MapIcon size={15} />}
-        </button>
+      {/* Toolbar — 3 equal buttons: Sort, Filter, Map */}
+      <div className="flex items-center py-2" style={{ paddingLeft: Spacing.md, paddingRight: Spacing.md, gap: 6, backgroundColor: Surface.surface }}>
+        <ToolbarPill active={showSort} onClick={() => { setShowSort(!showSort); setShowFilter(false); }} icon={<ArrowUpDown size={13} />} label="Sortera" />
+        <ToolbarPill active={showFilter} onClick={() => { setShowFilter(!showFilter); setShowSort(false); }} icon={<SlidersHorizontal size={13} />} label="Filter" badge={tagCodes.length > 0 ? tagCodes.length : undefined} />
+        <ToolbarPill active={showMap} onClick={onToggleMap} icon={showMap ? <List size={13} /> : <MapIcon size={13} />} label={showMap ? "Lista" : "Karta"} />
       </div>
 
-      {/* Sort dropdown */}
+      {/* Sort dropdown — functional */}
       {showSort && (
-        <div className="mx-4 mb-2 rounded-xl overflow-hidden border" style={{ borderColor: BRAND.border, backgroundColor: BRAND.surface }}>
-          {["Datum (närmast)", "Datum (längst bort)", "A-Ö"].map((opt) => (
-            <button key={opt} className="w-full text-left px-4 py-2.5 text-[12px] font-medium hover:bg-gray-50 transition-colors" style={{ color: BRAND.textBody }}>
-              {opt}
-            </button>
-          ))}
+        <div className="mx-4 mb-2 overflow-hidden border" style={{ borderRadius: Radii.card, borderColor: Neutral[200], backgroundColor: Surface.surface }}>
+          {SORT_OPTIONS.map((opt) => {
+            const active = sortMode === opt.mode;
+            return (
+              <button
+                key={opt.mode}
+                onClick={() => handleSort(opt.mode)}
+                className="w-full text-left px-4 py-2.5 flex items-center gap-2 transition-colors"
+                style={{
+                  fontSize: Typography.caption.size,
+                  fontWeight: active ? 700 : 500,
+                  color: active ? Neutral[800] : Neutral[700],
+                  backgroundColor: active ? Neutral[100] : "transparent",
+                }}
+              >
+                {active && <Check size={14} style={{ color: Neutral[800] }} />}
+                <span>{opt.label}</span>
+              </button>
+            );
+          })}
         </div>
       )}
 
-      {/* Filter tags dropdown */}
+      {/* Filter tags dropdown — matches GodoChip filter variant */}
       {showFilter && (
-        <div className="flex gap-1.5 flex-wrap px-4 pb-2">
+        <div className="flex flex-wrap px-4 pb-2" style={{ gap: 6 }}>
           {filterOptions.map((tag) => {
             const active = tagCodes.includes(tag.code);
             return (
               <button
                 key={tag.code}
                 onClick={() => toggleTag(tag.code)}
-                className="flex-shrink-0 px-3 py-1.5 rounded-full text-[11px] font-medium transition-colors"
+                className="flex-shrink-0 flex items-center transition-colors"
                 style={{
-                  backgroundColor: active ? BRAND.yellow : BRAND.neutral100,
-                  color: active ? BRAND.onPrimary : BRAND.textSecondary,
+                  height: 36,
+                  paddingLeft: 14,
+                  paddingRight: 14,
+                  borderRadius: Radii.pill,
+                  gap: 6,
+                  backgroundColor: active ? Neutral[200] : Surface.elevated,
+                  color: active ? Neutral[800] : Neutral[600],
+                  border: active ? `1.5px solid ${Neutral[500]}` : `1.5px solid ${Neutral[300]}`,
+                  fontSize: Typography.meta.size + 1,
+                  fontWeight: active ? 700 : 500,
                 }}
               >
+                {active && (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
                 {tag.label}
               </button>
             );
@@ -193,16 +246,52 @@ export function ResultsScreen({
         </div>
       )}
 
-      {/* Subcategory filter chips */}
+      {/* City + Date display */}
+      <div className="flex py-2" style={{ paddingLeft: Spacing.md, paddingRight: Spacing.md, gap: Spacing.sm }}>
+        <div
+          className="flex-1 flex items-center gap-1.5 px-3"
+          style={{
+            height: 40,
+            borderRadius: Radii.pill,
+            fontSize: Typography.caption.size,
+            fontWeight: 500,
+            backgroundColor: cities && cities.length > 0 ? GodoYellow[500] : Neutral[100],
+            color: cities && cities.length > 0 ? Surface.onPrimary : Neutral[700],
+          }}
+        >
+          <MapPin size={14} />
+          <span className="flex-1 text-left truncate">{cityDisplay}</span>
+        </div>
+        <div
+          className="flex-1 flex items-center gap-1.5 px-3"
+          style={{
+            height: 40,
+            borderRadius: Radii.pill,
+            fontSize: Typography.caption.size,
+            fontWeight: 500,
+            backgroundColor: startDate ? GodoYellow[500] : Neutral[100],
+            color: startDate ? Surface.onPrimary : Neutral[700],
+          }}
+        >
+          <CalendarDays size={14} />
+          <span className="flex-1 text-left truncate">{dateDisplay}</span>
+        </div>
+      </div>
+
+      {/* Subcategory filter chips — matches GodoChip category variant */}
       {subcategories.length > 0 && (
-        <div className="flex gap-1.5 overflow-x-auto px-4 py-2 scrollbar-hide">
+        <div className="flex overflow-x-auto px-4 py-2 scrollbar-hide" style={{ gap: 6 }}>
           <button
             onClick={() => setSelectedSub(null)}
-            className="flex-shrink-0 px-3 py-1.5 rounded-full text-[11px] font-semibold transition-colors"
+            className="flex-shrink-0 px-3 transition-colors"
             style={{
-              backgroundColor: selectedSub === null ? color : BRAND.surface,
-              color: selectedSub === null ? "#fff" : BRAND.textSecondary,
-              border: `1px solid ${selectedSub === null ? color : BRAND.border}`,
+              height: 36,
+              borderRadius: Radii.pill,
+              fontSize: 11,
+              fontWeight: 600,
+              backgroundColor: selectedSub === null ? color : Surface.surface,
+              color: selectedSub === null ? "#fff" : Neutral[500],
+              border: `1px solid ${selectedSub === null ? color : Neutral[200]}`,
             }}
           >
             Alla
@@ -213,11 +302,15 @@ export function ResultsScreen({
               <button
                 key={sub.code}
                 onClick={() => setSelectedSub(active ? null : sub.code)}
-                className="flex-shrink-0 px-2.5 py-1.5 rounded-full text-[10px] font-semibold transition-colors whitespace-nowrap"
+                className="flex-shrink-0 px-2.5 transition-colors whitespace-nowrap"
                 style={{
-                  backgroundColor: active ? color : BRAND.surface,
-                  color: active ? "#fff" : BRAND.textSecondary,
-                  border: `1px solid ${active ? color : BRAND.border}`,
+                  height: 36,
+                  borderRadius: Radii.pill,
+                  fontSize: Typography.caption.size - 2,
+                  fontWeight: 600,
+                  backgroundColor: active ? color : Surface.surface,
+                  color: active ? "#fff" : Neutral[500],
+                  border: `1px solid ${active ? color : Neutral[200]}`,
                 }}
               >
                 {sub.label}
@@ -232,52 +325,60 @@ export function ResultsScreen({
         <MapView events={events} categoryCode={categoryCode} onSelectEvent={onSelectEvent} />
       ) : (
         <div className="px-4 pb-4">
+          {/* Active sort indicator */}
+          {sortMode !== "date_asc" && (
+            <div className="flex items-center gap-1.5 mb-2">
+              <span style={{ fontSize: Typography.caption.size - 2, color: Neutral[500] }}>Sorterat:</span>
+              <span
+                className="px-2 py-0.5"
+                style={{ fontSize: Typography.caption.size - 2, fontWeight: 600, borderRadius: Radii.pill, backgroundColor: Neutral[100], color: Neutral[700] }}
+              >
+                {SORT_OPTIONS.find((s) => s.mode === sortMode)?.label}
+              </span>
+            </div>
+          )}
+
           <div className="flex flex-col gap-2 mt-1">
             {events.map((event) => (
-              <ResultCard
-                key={event.id}
-                event={event}
-                accentColor={color}
-                tint={tint}
-                onClick={() => onSelectEvent(event.id)}
-              />
+              <EventCard key={event.id} event={event} onClick={() => onSelectEvent(event.id)} />
             ))}
           </div>
 
           {events.length === 0 && (
-            <p className="text-center text-[12px] py-8" style={{ color: BRAND.textSecondary }}>
-              Inga evenemang i denna kategori
+            <p className="text-center py-8" style={{ fontSize: Typography.caption.size, color: Neutral[500] }}>
+              Inga evenemang hittades med dessa filter
             </p>
           )}
 
-          {/* Pagination stub */}
           {events.length > 0 && (
             <div className="flex items-center justify-center gap-1.5 mt-4">
-              <span className="text-[10px]" style={{ color: BRAND.textSecondary }}>
+              <span style={{ fontSize: Typography.caption.size - 2, color: Neutral[500] }}>
                 Visar 1-{events.length} av {totalCount}
               </span>
-              <div className="flex gap-1 ml-2">
-                {[1, 2, 3].map((p) => (
-                  <button
-                    key={p}
-                    className="w-[30px] h-[30px] rounded-lg text-[11px] font-semibold flex items-center justify-center"
-                    style={{
-                      backgroundColor: p === 1 ? BRAND.yellow : BRAND.neutral100,
-                      color: p === 1 ? BRAND.onPrimary : BRAND.textSecondary,
-                    }}
-                  >
-                    {p}
-                  </button>
-                ))}
-              </div>
+              {totalCount > events.length && (
+                <div className="flex gap-1 ml-2">
+                  {[1, 2, 3].map((p) => (
+                    <button
+                      key={p}
+                      className="flex items-center justify-center"
+                      style={{
+                        width: 30, height: 30,
+                        borderRadius: Radii.sm,
+                        fontSize: 11, fontWeight: 600,
+                        backgroundColor: p === 1 ? GodoYellow[500] : Neutral[100],
+                        color: p === 1 ? Surface.onPrimary : Neutral[500],
+                      }}
+                    >
+                      {p}
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
           )}
 
-          {/* Provider info */}
           <div className="mt-3 text-center">
-            <p className="text-[9px]" style={{ color: BRAND.neutral300 }}>
-              Data: Go.Do + Helsingborg Events API
-            </p>
+            <p style={{ fontSize: 9, color: Neutral[300] }}>Data: Go.Do + Helsingborg Events API</p>
           </div>
         </div>
       )}
@@ -285,95 +386,175 @@ export function ResultsScreen({
   );
 }
 
-function ToolbarPill({
-  active,
-  onClick,
-  icon,
-  label,
-}: {
-  active: boolean;
-  onClick: () => void;
-  icon: React.ReactNode;
-  label: string;
+/* ── Toolbar pill ─────────────────────────────────────────────── */
+function ToolbarPill({ active, onClick, icon, label, badge }: {
+  active: boolean; onClick: () => void; icon: React.ReactNode; label: string; badge?: number;
 }) {
   return (
     <button
       onClick={onClick}
-      className="flex items-center gap-1 px-3 h-[34px] rounded-full text-[11px] font-medium transition-colors"
+      className="flex-1 flex items-center justify-center gap-1 transition-colors"
       style={{
-        backgroundColor: active ? BRAND.yellow : BRAND.neutral100,
-        color: active ? BRAND.onPrimary : BRAND.textSecondary,
+        height: 34,
+        borderRadius: Radii.pill,
+        fontSize: 11,
+        fontWeight: 500,
+        fontFamily: FontFamily.body,
+        backgroundColor: active ? GodoYellow[500] : Neutral[100],
+        color: active ? Surface.onPrimary : Neutral[500],
       }}
     >
       {icon}
       {label}
+      {badge !== undefined && badge > 0 && (
+        <span
+          className="ml-0.5 px-1.5 py-0.5"
+          style={{ fontSize: 9, fontWeight: 700, borderRadius: Radii.pill, backgroundColor: Neutral[800], color: "#FFFFFF" }}
+        >
+          {badge}
+        </span>
+      )}
     </button>
   );
 }
 
-function MapView({
-  events,
-  categoryCode,
-  onSelectEvent,
-}: {
-  events: EventDto[];
-  categoryCode: number;
-  onSelectEvent: (eventId: string) => void;
+/* ── Event card — matches Expo EventOne exactly ──────────────── */
+function EventCard({ event, onClick }: { event: EventDto; onClick: () => void }) {
+  const categoryCodes = event.categories?.map((c) => c.code) ?? [];
+  const stripeColors = categoryCodes.slice(0, 3).map((code) => CATEGORY_COLORS[code] ?? "#374151");
+  if (stripeColors.length === 0) stripeColors.push(CATEGORY_COLORS[1]!);
+
+  const dateLabel = event.startDate
+    ? format(new Date(event.startDate), "d MMM yyyy", { locale: sv })
+    : event.isAlwaysOpen ? "Alltid öppet" : "Datum saknas";
+
+  const displayTags: string[] = [];
+  if (event.tags) {
+    for (const tag of event.tags.slice(0, 4)) {
+      displayTags.push(tag.name);
+    }
+  }
+
+  return (
+    <button
+      onClick={onClick}
+      className="w-full text-left overflow-hidden transition-transform active:scale-[0.98] flex"
+      style={{
+        minHeight: 48,
+        borderRadius: Radii.sm,
+        backgroundColor: CoolPastels.secondary50,
+        border: `1px solid ${CoolPastels.secondary100}`,
+        boxShadow: `2px 0 4px ${stripeColors[0]}59`,
+      }}
+    >
+      {/* Color stripes (6px each, up to 3) */}
+      <div className="flex flex-row flex-shrink-0">
+        {stripeColors.map((clr, i) => (
+          <div key={i} className="self-stretch" style={{ width: 6, backgroundColor: clr }} />
+        ))}
+      </div>
+
+      {/* Card content */}
+      <div className="flex-1 flex flex-col min-w-0" style={{ padding: 12, gap: 5 }}>
+        {/* Title + heart */}
+        <div className="flex items-start gap-2">
+          <h3
+            className="line-clamp-2 flex-1 break-words"
+            style={{
+              fontSize: Typography.cardTitle.size,
+              fontWeight: Typography.cardTitle.weight,
+              lineHeight: `${Typography.cardTitle.lineHeight}px`,
+              color: CoolPastels.neutral800,
+              fontFamily: FontFamily.body,
+            }}
+          >
+            {event.title}
+          </h3>
+          <Heart size={22} className="flex-shrink-0 mt-0.5" style={{ color: CoolPastels.neutral400 }} />
+        </div>
+
+        {/* Meta row */}
+        <div className="flex items-center" style={{ gap: 4, fontSize: Typography.meta.size + 1, color: "#64748B", fontFamily: FontFamily.body }}>
+          {event.city && <span>{event.city},</span>}
+          <span>{dateLabel}</span>
+        </div>
+
+        {/* Tags — dark badges matching Expo EventOne */}
+        {displayTags.length > 0 && (
+          <div className="flex flex-wrap justify-end mt-1" style={{ gap: 6 }}>
+            {displayTags.map((tag) => (
+              <span
+                key={tag}
+                style={{
+                  fontSize: Typography.caption.size - 2,
+                  fontWeight: 600,
+                  paddingLeft: 6,
+                  paddingRight: 6,
+                  paddingTop: 2,
+                  paddingBottom: 2,
+                  borderRadius: 4,
+                  backgroundColor: CoolPastels.neutral800,
+                  color: "#FFFFFF",
+                }}
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </button>
+  );
+}
+
+/* ── Map view ─────────────────────────────────────────────────── */
+function MapView({ events, categoryCode, onSelectEvent }: {
+  events: EventDto[]; categoryCode: number; onSelectEvent: (eventId: string) => void;
 }) {
   const color = CATEGORY_COLORS[categoryCode] ?? CATEGORY_COLORS[1];
   const emoji = CATEGORY_EMOJIS[categoryCode] ?? "📍";
 
-  // Group events by city for pin placement
   const cityGroups = useMemo(() => {
     const groups: Record<string, { events: EventDto[]; loc: { lat: number; lng: number } }> = {};
     for (const ev of events) {
       const city = ev.city || "Helsingborg";
       if (!groups[city]) {
-        groups[city] = {
-          events: [],
-          loc: MOCK_LOCATIONS[city] ?? HELSINGBORG_CENTER,
-        };
+        groups[city] = { events: [], loc: MOCK_LOCATIONS[city] ?? HELSINGBORG_CENTER };
       }
       groups[city].events.push(ev);
     }
     return groups;
   }, [events]);
 
+  const positions: Record<string, { top: string; left: string }> = {
+    Helsingborg: { top: "30%", left: "38%" },
+    "Malmö": { top: "72%", left: "58%" },
+    Lund: { top: "62%", left: "42%" },
+    Landskrona: { top: "48%", left: "50%" },
+    "Ängelholm": { top: "18%", left: "52%" },
+    "Höganäs": { top: "22%", left: "30%" },
+  };
+
   return (
-    <div className="relative" style={{ height: "380px" }}>
-      {/* Map background with grid */}
+    <div className="relative mx-4 overflow-hidden border" style={{ height: 380, borderRadius: Radii.card, borderColor: Neutral[200], boxShadow: Shadows.md }}>
       <div
         className="absolute inset-0"
         style={{
           backgroundColor: "#E8F4E8",
-          backgroundImage: `
-            linear-gradient(rgba(255,255,255,0.4) 1px, transparent 1px),
-            linear-gradient(90deg, rgba(255,255,255,0.4) 1px, transparent 1px)
-          `,
+          backgroundImage: `linear-gradient(rgba(255,255,255,0.4) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.4) 1px, transparent 1px)`,
           backgroundSize: "40px 40px",
         }}
       >
-        {/* Water areas */}
         <div className="absolute top-0 right-0 w-[40%] h-[35%] rounded-bl-[60px]" style={{ backgroundColor: "#B3D9F2" }} />
         <div className="absolute bottom-[10%] left-[5%] w-[15%] h-[12%] rounded-full" style={{ backgroundColor: "#B3D9F2" }} />
-
-        {/* Roads */}
         <div className="absolute top-[30%] left-0 right-0 h-[2px]" style={{ backgroundColor: "#D1D5DB" }} />
         <div className="absolute top-0 bottom-0 left-[35%] w-[2px]" style={{ backgroundColor: "#D1D5DB" }} />
         <div className="absolute top-[60%] left-0 right-[30%] h-[2px]" style={{ backgroundColor: "#D1D5DB" }} />
         <div className="absolute top-[15%] bottom-[20%] left-[65%] w-[2px]" style={{ backgroundColor: "#D1D5DB" }} />
       </div>
 
-      {/* Map pins */}
       {Object.entries(cityGroups).map(([city, { events: cityEvents }], i) => {
-        // Position pins roughly based on city
-        const positions: Record<string, { top: string; left: string }> = {
-          Helsingborg: { top: "30%", left: "40%" },
-          "Malmö": { top: "65%", left: "55%" },
-          Lund: { top: "55%", left: "30%" },
-        };
-        const pos = positions[city] ?? { top: `${30 + i * 20}%`, left: `${30 + i * 15}%` };
-
+        const pos = positions[city] ?? { top: `${25 + i * 12}%`, left: `${25 + i * 10}%` };
         return (
           <button
             key={city}
@@ -381,27 +562,20 @@ function MapView({
             className="absolute flex flex-col items-center -translate-x-1/2 -translate-y-full z-10 group"
             style={{ top: pos.top, left: pos.left }}
           >
-            {/* Pin bubble */}
             <div
-              className="relative px-2 py-1 rounded-xl flex items-center gap-1 shadow-md transition-transform group-hover:scale-110"
-              style={{ backgroundColor: color }}
+              className="relative px-2 py-1 flex items-center gap-1 shadow-md transition-transform group-hover:scale-110"
+              style={{ borderRadius: Radii.input, backgroundColor: color }}
             >
-              <span className="text-[12px]">{emoji}</span>
-              <span className="text-[10px] font-bold text-white">{cityEvents.length}</span>
-              {/* Pin arrow */}
+              <span style={{ fontSize: 12 }}>{emoji}</span>
+              <span style={{ fontSize: 10, fontWeight: 700, color: "#FFFFFF" }}>{cityEvents.length}</span>
               <div
                 className="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-0 h-0"
-                style={{
-                  borderLeft: "5px solid transparent",
-                  borderRight: "5px solid transparent",
-                  borderTop: `6px solid ${color}`,
-                }}
+                style={{ borderLeft: "5px solid transparent", borderRight: "5px solid transparent", borderTop: `6px solid ${color}` }}
               />
             </div>
-            {/* City label */}
             <span
-              className="text-[9px] font-semibold mt-2 px-1.5 py-0.5 rounded bg-white/90 shadow-sm"
-              style={{ color: BRAND.textPrimary }}
+              className="mt-2 px-1.5 py-0.5 bg-white/90 shadow-sm"
+              style={{ fontSize: 9, fontWeight: 600, borderRadius: Radii.sm, color: Neutral[800] }}
             >
               {city}
             </span>
@@ -409,86 +583,9 @@ function MapView({
         );
       })}
 
-      {/* Map attribution */}
-      <div className="absolute bottom-2 right-2 text-[8px] px-1.5 py-0.5 rounded bg-white/80" style={{ color: BRAND.textSecondary }}>
+      <div className="absolute bottom-2 right-2 px-1.5 py-0.5 bg-white/80" style={{ fontSize: 8, borderRadius: Radii.sm, color: Neutral[500] }}>
         Go.Do Map Preview
       </div>
     </div>
-  );
-}
-
-function ResultCard({
-  event,
-  accentColor,
-  tint,
-  onClick,
-}: {
-  event: EventDto;
-  accentColor: string;
-  tint: string;
-  onClick: () => void;
-}) {
-  const dateLabel = event.startDate
-    ? format(new Date(event.startDate), "d MMM yyyy", { locale: sv })
-    : event.isAlwaysOpen
-      ? "Alltid öppet"
-      : "Datum saknas";
-
-  return (
-    <button
-      onClick={onClick}
-      className="w-full text-left rounded-[18px] overflow-hidden border transition-transform active:scale-[0.98]"
-      style={{
-        borderColor: BRAND.border,
-        backgroundColor: BRAND.surface,
-        boxShadow: "0 1px 3px rgba(0,0,0,0.04)",
-      }}
-    >
-      <div className="flex">
-        {/* Color strip */}
-        <div className="w-1.5 flex-shrink-0" style={{ backgroundColor: accentColor }} />
-
-        <div className="flex-1 p-3 min-w-0">
-          {/* Colored dot + title */}
-          <div className="flex items-start gap-2 mb-1">
-            <div
-              className="w-[14px] h-[14px] rounded-full flex-shrink-0 mt-0.5"
-              style={{ backgroundColor: accentColor }}
-            />
-            <h3
-              className="text-[13px] font-semibold leading-snug line-clamp-2 break-words"
-              style={{ color: BRAND.textPrimary, letterSpacing: "0.25px" }}
-            >
-              {event.title}
-            </h3>
-          </div>
-
-          {event.subcategories?.[0] && (
-            <span
-              className="inline-block text-[9px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full mb-1.5 ml-[22px]"
-              style={{ backgroundColor: tint, color: accentColor }}
-            >
-              {event.subcategories[0].name}
-            </span>
-          )}
-
-          <div
-            className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] ml-[22px]"
-            style={{ color: BRAND.textSecondary }}
-          >
-            {event.city && (
-              <span className="flex items-center gap-1">
-                <MapPin size={11} className="flex-shrink-0" />
-                <span className="truncate max-w-[100px]">{event.city}</span>
-              </span>
-            )}
-            <span className="flex items-center gap-1">
-              <CalendarDays size={11} className="flex-shrink-0" />
-              {dateLabel}
-            </span>
-          </div>
-        </div>
-      </div>
-    </button>
   );
 }

--- a/src/lib/content/contentText.tsx
+++ b/src/lib/content/contentText.tsx
@@ -12,7 +12,7 @@ import {
   BookOpen,
   GraduationCap,
   HeartPulse,
-  Dumbbell,
+  Smile,
   Home,
   Accessibility,
   Glasses,
@@ -24,47 +24,54 @@ import {
   UtensilsCrossed,
   Compass,
   MessageCircle,
-  Lightbulb,
   UsersRound,
   Waves,
   HandHeart,
   Church,
+  Baby,
+  PersonStanding,
 } from "lucide-react";
 import { JSX } from "react";
 
 // ────────────────────────────────────────────────────────────────
-// 7 Categories / 21 Subcategories — aligned with backend DataSeeder
+// 8 Categories / 24 Subcategories — aligned with backend DataSeeder
 // Pattern: subcategory code = categoryCode * 100 + index
+// Display order: family-friendly first, then broad → niche
 // ────────────────────────────────────────────────────────────────
 
 export const subcategoriesMap: Record<
   number,
   { code: number; label: string; icon: React.ElementType }[]
 > = {
+  8: [
+    { code: 801, label: "0–4 år", icon: Baby },
+    { code: 802, label: "5–10 år", icon: Smile },
+    { code: 803, label: "11–15 år", icon: PersonStanding },
+  ],
   1: [
     { code: 101, label: "Festivaler & nöjen", icon: Sparkles },
     { code: 102, label: "Fritid & livsstil", icon: Users },
     { code: 103, label: "Mässor & marknader", icon: CalendarDays },
-  ],
-  2: [
-    { code: 201, label: "Sport att utöva", icon: Dribbble },
-    { code: 202, label: "Sport att titta på", icon: Eye },
-    { code: 203, label: "Sport att prova", icon: Mountain },
   ],
   3: [
     { code: 301, label: "Bio & film", icon: Film },
     { code: 302, label: "Musik & konserter", icon: Music },
     { code: 303, label: "Teater & shower", icon: Theater },
   ],
-  4: [
-    { code: 401, label: "Guidade turer", icon: Map },
-    { code: 402, label: "Konst & gallerier", icon: Paintbrush2 },
-    { code: 403, label: "Museer & sevärdheter", icon: Landmark },
+  2: [
+    { code: 201, label: "Sport att utöva", icon: Dribbble },
+    { code: 202, label: "Sport att titta på", icon: Eye },
+    { code: 203, label: "Sport att prova", icon: Mountain },
   ],
   5: [
     { code: 501, label: "Parker & leder", icon: TreeDeciduous },
     { code: 502, label: "Mat & dryck", icon: UtensilsCrossed },
     { code: 503, label: "Utflykter & äventyr", icon: Compass },
+  ],
+  4: [
+    { code: 401, label: "Guidade turer", icon: Map },
+    { code: 402, label: "Konst & gallerier", icon: Paintbrush2 },
+    { code: 403, label: "Museer & sevärdheter", icon: Landmark },
   ],
   6: [
     { code: 601, label: "Föreläsningar", icon: MessageCircle },
@@ -78,12 +85,14 @@ export const subcategoriesMap: Record<
   ],
 };
 
+// Display order: family-friendly first, then broad → niche
 export const categoryOptions: { code: number; label: string; icon: React.ElementType }[] = [
+  { code: 8, label: "Kul för barn", icon: Smile },
   { code: 1, label: "Evenemang", icon: CalendarDays },
-  { code: 2, label: "Idrott & sport", icon: Dribbble },
   { code: 3, label: "Underhållning", icon: Film },
-  { code: 4, label: "Kultur & sevärdheter", icon: Landmark },
+  { code: 2, label: "Idrott & sport", icon: Dribbble },
   { code: 5, label: "Upplevelser & äventyr", icon: Mountain },
+  { code: 4, label: "Kultur & sevärdheter", icon: Landmark },
   { code: 6, label: "Lära & utforska", icon: BookOpen },
   { code: 7, label: "Hälsa & välmående", icon: HeartPulse },
 ];


### PR DESCRIPTION
## Summary
- Mirror Expo app's complete design token system (theme.ts) in preview: GodoYellow/Neutral ramps, Surface colors, Typography scale, Spacing (8pt grid), Radii, Shadows, FontFamily (Calibri for branding)
- Expand mock events from 63 to 119: all 8 categories with 10+ events each, 6 cities with 10+ events each, including new category 8 "Kul för barn"
- Make results page fully functional: sorting (date asc/desc, A-Ö), proper city/date filter display, subcategory filtering, tag filtering
- Match Expo component styles exactly: EventOne cards, GodoChip variants, GodoButton, language flags (22px, 48x48 touch targets), category tiles
- Remove category/tag pills from event detail page
- Reorder categories to family-friendly order (Kids first) across all screens

## Test plan
- [ ] Visit `/preview` and verify the phone mockup matches the Expo app visually
- [ ] Test search, city picker, date picker functionality
- [ ] Test Go.Do. button navigates to results with correct category
- [ ] Test sort options on results page (all 3 modes)
- [ ] Test filter tags on results page
- [ ] Test subcategory chips filter events correctly
- [ ] Verify "Kul för barn" category appears first in grid
- [ ] Verify event detail page has no category/tag pills
- [ ] Verify all 6 cities appear in city picker with events

🤖 Generated with [Claude Code](https://claude.com/claude-code)