### PR TITLE
feat: add bilingual privacy policy (EN + SV) — draft for legal review

### DIFF
--- a/.claude/current-work.md
+++ b/.claude/current-work.md
@@ -3,143 +3,89 @@
 > **This file is read at the start of every Claude Code session and updated on every commit/push.**
 > It provides continuity between sessions.
 
-Last updated: 2026-05-03
+Last updated: 2026-05-19
 
 ## Active Task
-**Preview Redesign — MobileApp Parity** (Issue #58, branch `feature/preview-mobileapp-parity`) — ✅ **COMPLETE** as of 2026-05-04. All 9 phases shipped. Phase 9 polish merged the temporary carousel-demo removal and final verification gates. PR opened to `main`. Awaiting Nemo Sensei's manual smoke + merge approval.
+**Privacy Policy page (bilingual, DRAFT)** — public-facing legal page required
+for App Store + Google Play submission of the mobile app.
 
-### Phase 1 done (2026-05-03):
-- `framer-motion` installed for gesture-driven 3D carousel + spring physics
-- Carlito brand font wired via `next/font/google` → `--font-brand`
-- `constants.ts` extended with `Semantic` colors; `FontFamily.brand` now uses CSS var
-- New primitives in `src/components/preview/ui/`: GodoButton, GodoCard, GodoChip, RGBBorderCard
+### What was done (2026-05-19):
 
-### Phase 2 done (2026-05-03):
-- New `src/components/preview/components/CategoryCarousel3D.tsx` — full Reanimated→framer-motion port (gesture-driven drag, ring-modulus index, ±35° rotateY, perspective 800, opacity falloff, spring snap damping 18 / stiffness 150 / mass 0.8)
-- `src/components/preview/categories.ts` — 8 Swedish categories + 24 subcategories matching MobileApp
-- Animated subcategory dropdown (height + opacity + marginTop, spring damping 20 / stiffness 200)
-- `prefers-reduced-motion` fallback: flat scroll-snap horizontal carousel
-- Visual verification page at `/preview/carousel-demo` (temporary — will be removed in Phase 9)
+**Privacy Policy (branch `feature/privacy-policy`):**
 
-### Phase 3 done (2026-05-03):
-- Full rewrite of `src/components/preview/screens/HomeScreen.tsx` around the new carousel
-- Layout (top→bottom): Header → Greeting → Search → 3D Carousel → Clear All (when dirty) → City + Near Me row → Date pill → Big Go.Do! button
-- Language toggle (SV/GB) actually flips the on-screen Swedish/English copy
-- Inline SVG flags (FlagSE, FlagGB) — Windows lacks colour emoji for regional flag codepoints
-- Calendar bottom-sheet modal: Swedish month/day labels, range selection, "Go.Set." confirm
-- City modal preserved with search, multi-select, count badge, "Alla städer" reset
-- Near Me pill is yellow with Lock icon (premium-locked placeholder — wired in Phase 8)
-- Live at `/preview` — `npm run dev` to view
+1. **`src/components/legal/DraftBanner.tsx`** — yellow banner shown across the top
+   of legal pages while pending counsel review.
+2. **`src/components/legal/LegalLayout.tsx`** — shared chrome (banner + minimal
+   header + language switch + back-to-home link). Keeps the long-form content
+   components out of layout concerns.
+3. **`src/components/legal/PrivacyPolicyEn.tsx`** — full English privacy policy.
+   Sections: who we are, what we collect, how we use it, GDPR legal bases,
+   subprocessors (Apple, Google, GleSYS, Resend, Expo), international transfers,
+   retention, GDPR rights (Art. 15-22), account deletion (Profile -> Delete
+   Account), children, security, changes, contact. Ends with HTML-comment block
+   mapping data items to the Apple Privacy Nutrition Label and Google Play Data
+   Safety form (copy-paste for App Store Connect / Play Console).
+4. **`src/components/legal/PrivacyPolicySv.tsx`** — Swedish translation, "du"
+   form to match the rest of the site. Same structure as EN; refers back to
+   EN page for the (English-only) console mappings to avoid drift.
+5. **`src/app/privacy/page.tsx`** — `/privacy` route. Server component, metadata
+   incl. `alternates.languages` for SEO hreflang.
+6. **`src/app/sv/privacy/page.tsx`** — `/sv/privacy` route, same pattern.
+7. **`src/components/global/Footer.tsx`** — new site-wide footer (first one in
+   the repo). Links to both language versions of the policy.
+8. **`src/app/landing/page.tsx`** — drop the Footer onto the landing page.
+9. **`src/app/(auth)/register/page.tsx`** — the "I agree to the terms" checkbox
+   label now links to `/privacy` so the disclosure is reachable from signup.
+10. **`src/app/robots.ts`** + **`src/app/sitemap.ts`** — Next.js App Router
+    metadata routes. Sitemap exposes `/landing`, `/privacy`, `/sv/privacy` and
+    declares hreflang alternates. `NEXT_PUBLIC_SITE_URL` honoured (defaults to
+    `https://godo-dev.nu`).
 
-### Phase 4 done (2026-05-03):
-- New `components/SpotlightCarousel.tsx` — 160dp, 4s auto-rotate, framer-motion crossfade, yellow glow border, Spotlight badge, color stripe, pause/play
-- `ResultsScreen.tsx` shows SpotlightCarousel at top (top-3 events) when in list view
-- Provider chip on each event card: "Helsingborgs stad" (blue) or "Go.Do" (yellow) based on `sourceProvider`
+Verified: `npx tsc --noEmit` clean, `npm run lint` clean, `npm run build`
+green; both pages prerendered as static, `/robots.txt` and `/sitemap.xml`
+appear in the build output.
 
-### Phase 9 done (2026-05-04):
-- Removed `/preview/carousel-demo` (Phase 2 visual-verification harness)
-- Clean rebuild — route count down from 13 to 12
-- Reduce-motion confirmed on the two animation-heavy surfaces (3D carousel flat fallback, RGB border static colour)
-- All gates green: `tsc --noEmit`, `npm run lint`, `npm run build`
-- PR opened to `main`
+### Decisions made
+- **No new i18n library.** Repo currently has zero i18n. Used a simple `/sv/*`
+  folder for the Swedish route instead of pulling in `next-intl`. Easy to
+  migrate later if/when other pages need translation.
+- **One canonical Apple/Google form mapping** lives in the EN page's HTML
+  comment block. Counsel only needs to reconcile it once.
+- **Account deletion path documented as Profile -> Delete Account** to satisfy
+  both Apple (since June 2022) and Google (since May 2024) requirements.
+- **Minimum age set to 16** (default GDPR Art. 8 Member-State maximum,
+  unchanged in Sweden). Flagged `TODO` for counsel.
+- **Privacy contact email** is `privacy@godo.nu` — flagged for counsel to set
+  up if not already.
 
-### Phase 8 done (2026-05-03):
-- ProfileScreen rewritten: signed-in card with yellow-circle avatar (initial), email, four nav rows (Sparade evenemang / Mina listor / Nära mig / Prenumeration with plan pill), red-bordered logout. Logged-out fallback preserved.
-- FavoritesScreen rewritten: signed-in event list grouped into Kommande + Tidigare, framer-motion swipe-to-remove (snap-back if not committed, animate off-screen + remove past −60dp), empty state, logged-out fallback preserved
-- New ListsScreen + ListDetailScreen + CreateListModal: list cards with yellow-tint icon + count + chevron + trash, premium-gated empty state, list detail reuses Favorites visual, bottom-sheet create modal with text input
-- New NearMeScreen + NearMePremiumPromptModal: 5–50km radius slider, distance-sorted event list with yellow km badges, list/map toggle, fake map placeholder with concentric radius rings + center pin + counter overlay
-- New SubscriptionScreen: header + plan-badge card + features-list card (yellow-circle checks) + conditional upgrade area or manage button
-- AppPreview state machine extended: `profileRoute` axis (lists / list-detail / near-me / subscription), mock account state (signedIn, favoriteIds, lists, isPremium), tab switch dismisses any active route, logout clears profileRoute and downgrades to Free
-- Discovery: ProfileScreen has 4 rows (added "Nära mig"); MobileApp profile has 3 (NearMe entry is a Home pill not yet wired in preview). Lean entry point for marketing demo.
-
-### Phase 7 done (2026-05-03):
-- New `screens/LoginScreen.tsx` — Calibri-Bold "Logga in" title, email + password inputs (Neutral[900] border), dark primary button (disabled until both fields filled), "Har du inget konto? Skapa konto" switch link
-- New `screens/RegisterScreen.tsx` — title + Swedish subtitle, email/password/confirm inputs, inline mismatch error (red), "Har du redan ett konto? Logga in" switch link
-- New `components/SocialLoginButtons.tsx` — port of MobileApp `SocialLoginButtons.tsx`. Two stacked Neutral[900] pill buttons with brand SVG marks (Google four-color G + Apple silhouette) and "eller" divider
-- AppPreview gets `authRoute` axis (login/register) layered above tabs; tab bar stays visible to mirror MobileApp `(tabs)/login.tsx` re-export pattern
-- `LoginPromptModal` and `ProfileScreen` CTAs now route to login / register
-- Tab switch dismisses any active auth route automatically
-- Login ↔ Register switch in-place (no dismiss)
-
-### Phase 6 done (2026-05-03):
-- AppPreview state machine refactored: `activeTab` (home/favorites/profile) + per-tab screen stack + modal stack
-- New `components/TabBar.tsx`: 3 tabs (Hem/Sparat/Profil), lucide icons, GodoYellow[500] active tint, framer-motion press scale, top divider
-- `PhoneFrame.tsx` accepts `bottomBar` + `overlay` slots (modals sit absolutely above content + bottomBar)
-- Tab bar hidden on event detail screen for immersive parity with MobileApp
-- New `components/LoginPromptModal.tsx`: bottom-sheet, framer-motion slide-up spring + fade backdrop, heart icon, primary "Logga in" + secondary "Skapa konto" — port of MobileApp `LoginPromptModal`
-- Placeholder `screens/FavoritesScreen.tsx` + `screens/ProfileScreen.tsx`: logged-out empty states with CTAs that drive the modal stack end-to-end (full versions in Phase 8)
-- Tapping Hem tab while already on it pops back to home root (mirrors MobileApp)
-
-### Phase 5 done (2026-05-03):
-- Full rewrite of `screens/EventDetailScreen.tsx` as faithful port of MobileApp `app/event/[id].tsx`
-- 300dp yellow brand-gradient hero (`GodoYellow[500]CC → GodoYellow[500]`), floating top-row buttons (back left; heart/calendar/share right) — 40dp white pills with framer-motion `whileTap` press-spring (damping 18 / stiffness 320)
-- Subcategory label on hero bottom-left
-- Rounded content sheet (-20 overlap), title 24/700, date+time 16/600, tag chips Neutral[100]/700
-- About / Arrangör / Plats / När sections with small uppercase labels
-- Inline action button row (NOT sticky — parity with MobileApp): Boka (Neutral[800] + Ticket), Besök webbplats (yellow + ExternalLink), Vägbeskrivning (transparent + Neutral[300] border + Navigate)
-- Heart button toggles favourited state (red fill when active)
-- Web Share API with clipboard fallback
-- New `components/CalendarConfirmModal.tsx` — bottom-sheet with framer-motion slide-up spring (damping 24 / stiffness 240) + fade backdrop, drag handle, GodoYellow[100] icon circle, Neutral[50] details box, yellow confirm + ghost cancel
-
-### Earlier history (preserved for reference):
-
-### What was done (2026-02-26):
-
-**Preview Redesign (PR #38, merged to main):**
-
-1. **`constants.ts`** — New design tokens matching Expo WCAG 2.1 AAA:
-   - Brand palette: Go.Do Yellow (#F3C10E), warm background (#FAF8F3), surface (#FFFEFA)
-   - Category colors with AAA contrast, soft tints, gradient pairs
-   - Category emojis for map pins, GPS mock locations
-2. **`PhoneFrame.tsx`** — Warm off-white background
-3. **`AppPreview.tsx`** — Multi-select categories, map toggle, Go.Do! flow
-4. **`HomeScreen.tsx`** — Category tiles with checkmarks, tag chips, Go.Do! button, upcoming cards, featured card with RGB border
-5. **`ResultsScreen.tsx`** — Toolbar, subcategory chips, styled map view with city pins, result cards, pagination
-6. **`EventDetailScreen.tsx`** — Hero gradient, floating buttons, tag pills, content sheet, sticky CTA
-7. **`globals.css`** — `@keyframes rgbShift` animation
-
-**Swedish Mock Events (PR #39, merged to main):**
-
-8. **`mockEvents.ts`** — 63 realistic Swedish events from Helsingborg/NV Skåne:
-   - Real organizers: Helsingborgs stad, Dunkers kulturhus, Sofiero Slott, Fredriksdals museer, HIF, Rögle BK
-   - Real addresses: Stortorget, Kungsgatan 11, Sofiero Slottsväg, Olympiavägen, Catena Arena
-   - All category/subcategory/tag names in Swedish
-   - Detailed Swedish descriptions
-
-**Documentation (PR #37, merged to main):**
-
-9. **`docs/ARCHITECTURE.md`** — 8 Mermaid diagrams for tech stack, user flow, data flow, JWT auth, form state, deployment
+### TODO markers for legal counsel to resolve (search for `<!-- TODO`):
+- Legal registered address (EN + SV)
+- Swedish organisation number
+- Whether a formal DPO / dataskyddsombud is appointed
+- Any additional subprocessors (analytics, error tracking, push notifications)
+- Confirm retention periods (currently proposed: 30 days post-deletion,
+  7 years for accounting, 90 days for logs, 30 days for backups)
+- Confirm minimum-age policy choice (currently 16)
+- Confirm Swedish term for "dataportabilitet" wording
+- Confirm legal postal address for the Contact section
 
 ### What's next:
-1. Connect preview to live API data (replace mock events with real API calls)
-2. Add real event images/thumbnails (currently gradient placeholders)
-3. Docker deployment to GleSYS VPS
-4. Consider adding search functionality to preview
+1. Get counsel sign-off and remove the DraftBanner + TODO comments
+2. Set the `/privacy` URL in App Store Connect and Google Play Console
+3. Fill in Apple Privacy Nutrition Label / Google Data Safety form using
+   the mapping in the HTML-comment block at the bottom of
+   `PrivacyPolicyEn.tsx`
+4. Consider also drafting a Terms & Conditions page (the register checkbox
+   already references one but no page exists yet)
+5. Add Footer to other top-level pages (login/register, my-events, etc.)
+   so the policy is reachable from everywhere
 
-## Key Decisions
-- **Preview matches Expo** — Phone mockup mirrors the accessibility-redesign branch design
-- **All Swedish** — Event titles, descriptions, organizers, categories, tags all in Swedish
-- **Go.Do Yellow #F3C10E** as primary brand color
-- **WCAG 2.1 AAA** — Contrast-safe category colors, 48dp touch targets
-- **Styled CSS map** — Preview uses CSS-based map (not real map integration)
-- **RGB animated border** — Featured card uses `@keyframes rgbShift` CSS animation
-
-## Project Structure (Preview Components)
-```
-src/components/preview/
-├── AppPreview.tsx          # State machine: home → results → detail
-├── PhoneFrame.tsx          # Phone bezel with status bar + home indicator
-├── constants.ts            # Design tokens matching Expo app
-├── mockEvents.ts           # 63 realistic Swedish events + filter helper
-└── screens/
-    ├── HomeScreen.tsx       # Category tiles, tags, Go.Do!, upcoming cards
-    ├── ResultsScreen.tsx    # Toolbar, map/list, subcategory chips, cards
-    └── EventDetailScreen.tsx # Hero, content sheet, sticky CTA
-```
+## Previous Session (2026-02-26)
+Preview Redesign (PRs #38/#39) and Architecture docs (PR #37) — see git log.
 
 ## Environment Notes
-- Frontend repo: `C:\InFiNetCode\Projects\GODO\FORM\Frontend`
-- Backend repo: `C:\InFiNetCode\Projects\GODO\BACKEND\Backend`
-- Mobile app repo: `C:\InFiNetCode\Projects\GODO\APP\MobileApp`
-- Preview page: `/preview` route
-- Build: `npx next build` (Next.js 16.1.4 with Turbopack)
+- Frontend repo: `C:/Nemanja/Företag/FIRMA/InFiNet Code AB/Projects/GODO/FEProject/godo-fe-web` (NOT what CLAUDE.md still says)
+- Backend repo: `C:/Nemanja/Företag/FIRMA/InFiNet Code AB/Projects/GODO/BEProject/CleanArchitectureBE-DOTNET`
+- Mobile app repo: `C:/Nemanja/Företag/FIRMA/InFiNet Code AB/Projects/GODO/APP/MobileApp`
+- Build: `npm run build` (Next.js 16.1.4 with Turbopack)
+- Production URL after deploy: `https://godo-dev.nu/privacy` and `https://godo-dev.nu/sv/privacy`

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -237,7 +237,15 @@ export default function OrganizerRegisterPage() {
                       })}
                     />
                     <Label htmlFor="acceptTerms" className="text-sm text-gray-700">
-                      I agree to the Terms and Conditions
+                      I agree to the Terms and Conditions and have read the{" "}
+                      <a
+                        href="/privacy"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline"
+                      >
+                        Privacy Policy
+                      </a>
                     </Label>
                   </div>
                   {errors.acceptTerms && (

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Navbar } from "@/components/global/Navbar";
+import { Footer } from "@/components/global/Footer";
 import { Button } from "@/components/ui/button";
 import { CalendarPlus, Zap, List, Smartphone } from "lucide-react";
 import Link from "next/link";
@@ -96,6 +97,8 @@ export default function Home() {
           )}
         </div>
       </section>
+
+      <Footer />
     </main>
   );
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { LegalLayout } from "@/components/legal/LegalLayout";
+import { PrivacyPolicyEn } from "@/components/legal/PrivacyPolicyEn";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Go.Do",
+  description:
+    "How Go.Do AB collects, uses, and protects personal data for the Go.Do mobile app, organiser website, and backend.",
+  alternates: {
+    canonical: "/privacy",
+    languages: {
+      en: "/privacy",
+      sv: "/sv/privacy",
+    },
+  },
+};
+
+export default function PrivacyPage() {
+  return (
+    <LegalLayout
+      draftBannerText="DRAFT — pending review by legal counsel before public launch."
+      languageSwitch={{ label: "Svenska", href: "/sv/privacy" }}
+      homeLabel="Back to Go.Do"
+    >
+      <PrivacyPolicyEn />
+    </LegalLayout>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://godo-dev.nu";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/my-events", "/create-event", "/quick-create"],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,33 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://godo-dev.nu";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  return [
+    {
+      url: `${SITE_URL}/landing`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/privacy`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.5,
+      alternates: {
+        languages: {
+          en: `${SITE_URL}/privacy`,
+          sv: `${SITE_URL}/sv/privacy`,
+        },
+      },
+    },
+    {
+      url: `${SITE_URL}/sv/privacy`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.5,
+    },
+  ];
+}

--- a/src/app/sv/privacy/page.tsx
+++ b/src/app/sv/privacy/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { LegalLayout } from "@/components/legal/LegalLayout";
+import { PrivacyPolicySv } from "@/components/legal/PrivacyPolicySv";
+
+export const metadata: Metadata = {
+  title: "Integritetspolicy | Go.Do",
+  description:
+    "Så samlar Go.Do AB in, använder och skyddar personuppgifter för Go.Do mobilapp, arrangörswebbplatsen och backend.",
+  alternates: {
+    canonical: "/sv/privacy",
+    languages: {
+      en: "/privacy",
+      sv: "/sv/privacy",
+    },
+  },
+};
+
+export default function PrivacyPageSv() {
+  return (
+    <LegalLayout
+      draftBannerText="UTKAST — väntar på granskning av juridiskt ombud före publik lansering."
+      languageSwitch={{ label: "English", href: "/privacy" }}
+      homeLabel="Tillbaka till Go.Do"
+    >
+      <PrivacyPolicySv />
+    </LegalLayout>
+  );
+}

--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+/**
+ * Site-wide footer with legal links.
+ *
+ * Kept intentionally small. The current site has no global footer; this is
+ * the first one. Page authors should drop <Footer /> into any layout that
+ * needs it. Mobile-app links are kept here so app-store listings can point
+ * straight to /privacy.
+ */
+export function Footer() {
+  return (
+    <footer className="w-full border-t bg-white text-sm text-gray-700">
+      <div className="max-w-7xl mx-auto px-6 py-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
+        <p className="text-gray-500">
+          &copy; {new Date().getFullYear()} Go.Do AB. All rights reserved.
+        </p>
+        <nav className="flex flex-wrap items-center gap-4">
+          <Link href="/privacy" className="hover:underline">
+            Privacy Policy
+          </Link>
+          <span aria-hidden="true" className="text-gray-300">
+            ·
+          </span>
+          <Link href="/sv/privacy" className="hover:underline">
+            Integritetspolicy
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/legal/DraftBanner.tsx
+++ b/src/components/legal/DraftBanner.tsx
@@ -1,0 +1,15 @@
+interface DraftBannerProps {
+  text: string;
+}
+
+export function DraftBanner({ text }: DraftBannerProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="w-full bg-yellow-100 border-b border-yellow-300 text-yellow-900 text-sm px-4 py-3 text-center font-medium"
+    >
+      {text}
+    </div>
+  );
+}

--- a/src/components/legal/LegalLayout.tsx
+++ b/src/components/legal/LegalLayout.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { DraftBanner } from "./DraftBanner";
+
+interface LegalLayoutProps {
+  draftBannerText: string;
+  languageSwitch: {
+    label: string;
+    href: string;
+  };
+  homeLabel: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared chrome for legal pages (privacy, terms, etc.).
+ * Keeps the actual policy content (which is long) out of the layout file
+ * so each component stays focused and easy to review.
+ */
+export function LegalLayout({
+  draftBannerText,
+  languageSwitch,
+  homeLabel,
+  children,
+}: LegalLayoutProps) {
+  return (
+    <div className="min-h-screen bg-white text-gray-900">
+      <DraftBanner text={draftBannerText} />
+
+      <header className="border-b bg-white">
+        <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between text-sm">
+          <Link href="/landing" className="font-semibold text-gray-900 hover:underline">
+            Go.Do.
+          </Link>
+          <div className="flex items-center gap-4">
+            <Link href={languageSwitch.href} className="text-gray-700 hover:underline">
+              {languageSwitch.label}
+            </Link>
+            <Link href="/landing" className="text-gray-700 hover:underline">
+              {homeLabel}
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-6 py-10">
+        <article className="prose prose-sm sm:prose-base max-w-none">{children}</article>
+      </main>
+    </div>
+  );
+}

--- a/src/components/legal/PrivacyPolicyEn.tsx
+++ b/src/components/legal/PrivacyPolicyEn.tsx
@@ -1,0 +1,499 @@
+/**
+ * English-language Privacy Policy content.
+ *
+ * Authored as a strong DRAFT. All values still pending legal review are
+ * flagged with `<!-- TODO: confirm ... -->` in JSX comments and rendered
+ * as visible "[TBD]" markers so legal counsel can locate them on a
+ * printed/exported copy.
+ */
+export function PrivacyPolicyEn() {
+  return (
+    <>
+      <h1 className="text-3xl font-bold mb-2">Privacy Policy</h1>
+      <p className="text-sm text-gray-600 mb-8">
+        Effective date: 19 May 2026 · Last updated: 19 May 2026
+      </p>
+
+      <p>
+        This Privacy Policy describes how <strong>Go.Do AB</strong> (&quot;Go.Do&quot;,
+        &quot;we&quot;, &quot;us&quot;, &quot;our&quot;) collects, uses, and protects your personal
+        data when you use the Go.Do mobile application (iOS and Android, package{" "}
+        <code>nu.godo.app</code>), the Go.Do organiser website at{" "}
+        <a href="https://godo-dev.nu" className="underline">
+          godo-dev.nu
+        </a>
+        , and our backend services (together, the &quot;Service&quot;).
+      </p>
+
+      <p>
+        Go.Do AB is the <strong>data controller</strong> for the personal data described in this
+        policy, in accordance with the EU General Data Protection Regulation (Regulation (EU)
+        2016/679, &quot;GDPR&quot;) and the Swedish Data Protection Act (2018:218).
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">1. Who we are</h2>
+      <p>
+        <strong>Go.Do AB</strong>
+        <br />
+        Sweden
+        <br />
+        {/* TODO: confirm legal registered address (street, postal code, city) */}
+        Registered address: <em>[TBD — pending counsel]</em>
+        <br />
+        {/* TODO: confirm Swedish organisation number */}
+        Organisation number: <em>[TBD — pending counsel]</em>
+        <br />
+        Contact for privacy matters:{" "}
+        <a href="mailto:privacy@godo.nu" className="underline">
+          privacy@godo.nu
+        </a>
+      </p>
+      <p>
+        {/* TODO: confirm whether a formal DPO is appointed; if not, name the responsible privacy contact role */}
+        We have appointed a privacy contact who is responsible for overseeing questions in
+        relation to this Privacy Policy. If you have any questions about this Privacy Policy,
+        including any requests to exercise your legal rights, please contact us at the email
+        above.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">2. What data we collect</h2>
+      <p>We collect only the data we need to operate the Service. Specifically:</p>
+
+      <h3 className="mt-6">2.1 Account information</h3>
+      <ul>
+        <li>
+          <strong>Email address</strong> — required to create an account, log in, and receive
+          essential service emails (password reset, account notices).
+        </li>
+        <li>
+          <strong>Name</strong> — required at registration and displayed in your profile.
+        </li>
+        <li>
+          <strong>Password</strong> (if you registered with email and password) — stored as a
+          salted hash using HMAC-SHA512 with a per-user random salt. We never store passwords in
+          plain text and we never see your password. Accounts created via social login only
+          (Apple or Google) have no password stored at all.
+        </li>
+        <li>
+          <strong>Role</strong> — whether you are a regular user, an event organiser, or an
+          administrator. This determines what features you can access.
+        </li>
+      </ul>
+
+      <h3 className="mt-6">2.2 Authentication providers (social login)</h3>
+      <p>
+        If you sign in with Google or Apple, we receive a stable identifier and your email
+        address from that provider. We do <strong>not</strong> receive your social-network
+        password.
+      </p>
+      <ul>
+        <li>
+          <strong>Google Sign-In</strong> via the official Google Identity Services library
+          (mobile: <code>@react-native-google-signin/google-signin</code>).
+        </li>
+        <li>
+          <strong>Apple Sign in with Apple</strong> via{" "}
+          <code>expo-apple-authentication</code>. Apple may return a private relay email; we
+          treat it the same way as a normal email.
+        </li>
+      </ul>
+
+      <h3 className="mt-6">2.3 Location data (optional)</h3>
+      <p>
+        With your permission, the mobile app may use your <strong>approximate</strong> or{" "}
+        <strong>precise</strong> location to find events near you and to show your position on
+        the in-app map. You can grant or deny this permission at any time in your device
+        settings. The Service still works without location access — you simply pick a city
+        manually.
+      </p>
+
+      <h3 className="mt-6">2.4 Calendar access (optional)</h3>
+      <p>
+        With your permission, the mobile app can read and write entries in your device calendar,
+        so you can add an event you are interested in to your own calendar with one tap. We do
+        not transmit your calendar contents to our servers; the read/write happens locally on
+        your device.
+      </p>
+
+      <h3 className="mt-6">2.5 In-app purchases and subscriptions</h3>
+      <p>
+        Premium features (such as Spotlight promotions and Premium subscriptions) are billed
+        through <strong>Apple App Store</strong> (in-app purchases) or{" "}
+        <strong>Google Play Billing</strong>. Apple and Google process your payment and we{" "}
+        <strong>never see your card number or full payment details</strong>. We receive only:
+      </p>
+      <ul>
+        <li>A receipt or purchase token that we validate server-side to confirm the purchase.</li>
+        <li>The product identifier you purchased (e.g. premium tier).</li>
+        <li>Purchase and renewal status, so we can grant or revoke entitlements.</li>
+      </ul>
+
+      <h3 className="mt-6">2.6 Authentication tokens stored on your device</h3>
+      <p>
+        After login, we store a short-lived access token (about 5 minutes) and a refresh token
+        in your device&apos;s secure storage (iOS Keychain / Android Keystore, via{" "}
+        <code>expo-secure-store</code>). These tokens stay on your device and are sent only to
+        our API when you make a request.
+      </p>
+
+      <h3 className="mt-6">2.7 Usage data</h3>
+      <p>
+        We record, in general terms, how the Service is used: which event listings are viewed,
+        which categories and filters are selected, and similar product analytics. We use this to
+        improve the Service. We do not sell this data and we do not use it for cross-app
+        tracking.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">3. How we use your data</h2>
+      <table className="my-4 border-collapse">
+        <thead>
+          <tr className="text-left">
+            <th className="border p-2">Data type</th>
+            <th className="border p-2">Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border p-2">Email, name, password hash</td>
+            <td className="border p-2">Create and secure your account; sign you in.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Social-login identifier</td>
+            <td className="border p-2">Sign you in via Apple or Google.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Location</td>
+            <td className="border p-2">Show events near you; sort results by distance.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Calendar access</td>
+            <td className="border p-2">Add events you select to your device calendar.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Purchase receipts</td>
+            <td className="border p-2">Grant access to paid features; handle refunds.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Auth tokens</td>
+            <td className="border p-2">Keep you signed in securely between sessions.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Usage data</td>
+            <td className="border p-2">Improve the Service, fix bugs, prioritise features.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">4. Legal bases (GDPR Article 6)</h2>
+      <ul>
+        <li>
+          <strong>Performance of a contract</strong> (Art. 6(1)(b)) — to create your account,
+          deliver the Service you signed up for, and process purchases.
+        </li>
+        <li>
+          <strong>Legitimate interests</strong> (Art. 6(1)(f)) — to operate, secure, and improve
+          the Service (e.g. fraud prevention, basic product analytics). We balance this against
+          your rights and freedoms.
+        </li>
+        <li>
+          <strong>Consent</strong> (Art. 6(1)(a)) — for optional features that require your
+          permission, such as location and calendar access. You may withdraw consent at any
+          time, with no effect on the lawfulness of processing before withdrawal.
+        </li>
+        <li>
+          <strong>Legal obligation</strong> (Art. 6(1)(c)) — where we must retain records (for
+          example, accounting records for purchases, under Swedish bookkeeping law).
+        </li>
+      </ul>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">5. Sharing and third-party processors</h2>
+      <p>
+        We do not sell your personal data. We share data only with the service providers
+        (&quot;processors&quot;) we need to run the Service. Each processor handles data on our
+        instructions under a data processing agreement.
+      </p>
+      <table className="my-4 border-collapse">
+        <thead>
+          <tr className="text-left">
+            <th className="border p-2">Processor</th>
+            <th className="border p-2">Purpose</th>
+            <th className="border p-2">Location</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border p-2">Apple Inc.</td>
+            <td className="border p-2">
+              iOS app distribution, Sign in with Apple, App Store in-app purchases.
+            </td>
+            <td className="border p-2">US / global</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Google LLC</td>
+            <td className="border p-2">
+              Google Play distribution, Google Sign-In, Google Maps (event locations), Play
+              Billing.
+            </td>
+            <td className="border p-2">US / global</td>
+          </tr>
+          <tr>
+            <td className="border p-2">GleSYS AB</td>
+            <td className="border p-2">
+              Primary infrastructure host (servers, database, backups).
+            </td>
+            <td className="border p-2">Sweden (EU)</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Resend</td>
+            <td className="border p-2">
+              Transactional email delivery (password reset, account notices).
+            </td>
+            <td className="border p-2">US / EU</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Expo / EAS (Expo Inc.)</td>
+            <td className="border p-2">
+              Mobile build and over-the-air update tooling. No end-user personal data is sent
+              to Expo by the Service.
+            </td>
+            <td className="border p-2">US</td>
+          </tr>
+        </tbody>
+      </table>
+      {/* TODO: confirm any other subprocessors (e.g. analytics, error tracking, push notification provider) */}
+      <p className="text-xs text-gray-500">
+        [TBD — counsel to confirm whether any additional subprocessors are in use (analytics,
+        error tracking, push notifications, etc.).]
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">6. International transfers</h2>
+      <p>
+        Most of your personal data is processed on servers located in <strong>Sweden</strong>{" "}
+        (EU/EEA). However, certain processors (notably Apple, Google, Resend, and Expo) may
+        transfer or access personal data outside the EEA — typically to the United States.
+        Where this happens, we rely on the European Commission&apos;s Standard Contractual
+        Clauses (SCCs) and any additional safeguards required under Articles 44–49 of the GDPR.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">7. Data retention</h2>
+      {/* TODO: confirm retention periods — defaults below are reasonable but legal counsel should sign off */}
+      <ul>
+        <li>
+          <strong>Active accounts</strong> — kept for as long as your account exists.
+        </li>
+        <li>
+          <strong>Deleted accounts</strong> — personal data is deleted or anonymised within{" "}
+          <em>[TBD — proposed: 30 days]</em> after you delete your account, except where we are
+          required to retain certain records by law.
+        </li>
+        <li>
+          <strong>Purchase / billing records</strong> — retained for{" "}
+          <em>[TBD — proposed: 7 years]</em> to comply with the Swedish Bookkeeping Act
+          (Bokföringslagen 1999:1078).
+        </li>
+        <li>
+          <strong>Server logs</strong> — retained for{" "}
+          <em>[TBD — proposed: 90 days]</em> for security and debugging.
+        </li>
+        <li>
+          <strong>Backups</strong> — encrypted backups rotate out within{" "}
+          <em>[TBD — proposed: 30 days]</em>.
+        </li>
+      </ul>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">8. Your rights</h2>
+      <p>Under the GDPR (Articles 15–22), you have the right to:</p>
+      <ul>
+        <li>
+          <strong>Access</strong> the personal data we hold about you (Art. 15).
+        </li>
+        <li>
+          <strong>Rectify</strong> data that is inaccurate or incomplete (Art. 16).
+        </li>
+        <li>
+          <strong>Erase</strong> your data (&quot;right to be forgotten&quot;, Art. 17). You can
+          do this yourself in the app — see Section 9 below.
+        </li>
+        <li>
+          <strong>Restrict processing</strong> of your data (Art. 18).
+        </li>
+        <li>
+          <strong>Data portability</strong> — receive your data in a machine-readable format
+          (Art. 20).
+        </li>
+        <li>
+          <strong>Object</strong> to processing based on legitimate interests (Art. 21).
+        </li>
+        <li>
+          <strong>Withdraw consent</strong> at any time, where processing is based on consent
+          (Art. 7(3)).
+        </li>
+        <li>
+          <strong>Lodge a complaint</strong> with the Swedish supervisory authority,{" "}
+          <strong>Integritetsskyddsmyndigheten (IMY)</strong> —{" "}
+          <a href="https://www.imy.se" className="underline">
+            imy.se
+          </a>{" "}
+          — or with the supervisory authority in your EU country of residence.
+        </li>
+      </ul>
+      <p>
+        To exercise any of these rights, email us at{" "}
+        <a href="mailto:privacy@godo.nu" className="underline">
+          privacy@godo.nu
+        </a>
+        . We will respond within one month (with a possible two-month extension for complex
+        requests, as permitted by GDPR Art. 12(3)).
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">9. Account deletion</h2>
+      <p>You can delete your Go.Do account at any time, directly inside the mobile app:</p>
+      <ol>
+        <li>
+          Open the Go.Do app and sign in.
+        </li>
+        <li>
+          Go to the <strong>Profile</strong> tab.
+        </li>
+        <li>
+          Tap <strong>Delete Account</strong> and confirm.
+        </li>
+      </ol>
+      <p>
+        Once you confirm, your account is scheduled for deletion. Personal data is removed or
+        anonymised in accordance with the retention rules in Section 7. Some records (notably
+        purchase / accounting records) must be kept by law and will be retained for the period
+        required, then deleted.
+      </p>
+      <p>
+        If you cannot access the app for any reason, email{" "}
+        <a href="mailto:privacy@godo.nu" className="underline">
+          privacy@godo.nu
+        </a>{" "}
+        from the email address linked to your account and we will process the deletion for you.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">10. Children&apos;s privacy</h2>
+      {/* TODO: confirm minimum age — default is 16 to align with GDPR Art. 8 (Sweden has not lowered it) */}
+      <p>
+        The Service is not intended for children under <strong>16</strong>. We do not knowingly
+        collect personal data from a child under 16. If you are a parent or guardian and you
+        believe your child has provided us with personal data, please contact us and we will
+        delete the data.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">11. Security</h2>
+      <ul>
+        <li>All communication with our API is encrypted over <strong>HTTPS (TLS)</strong>.</li>
+        <li>
+          Passwords are stored as <strong>HMAC-SHA512 hashes with a unique salt per user</strong>
+          . We never log or store plain-text passwords.
+        </li>
+        <li>
+          In-app purchase receipts are <strong>validated server-side</strong> against Apple and
+          Google — clients cannot grant themselves access to paid features.
+        </li>
+        <li>
+          Access tokens on your device are stored in the operating system&apos;s secure
+          storage (iOS Keychain / Android Keystore).
+        </li>
+        <li>
+          We restrict internal access to personal data on a least-privilege basis and review
+          access regularly.
+        </li>
+      </ul>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">12. Changes to this policy</h2>
+      <p>
+        We may update this Privacy Policy from time to time. When we make material changes, we
+        will update the &quot;Last updated&quot; date at the top of this page and, where
+        appropriate, notify you in the app or by email. Continuing to use the Service after a
+        change means you accept the updated policy. We encourage you to review this page
+        periodically.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">13. Contact</h2>
+      <p>
+        For any privacy-related question or to exercise a right above, contact:
+        <br />
+        <strong>Go.Do AB</strong>
+        <br />
+        <a href="mailto:privacy@godo.nu" className="underline">
+          privacy@godo.nu
+        </a>
+        <br />
+        {/* TODO: confirm legal postal address */}
+        <em>[Legal postal address TBD — pending counsel]</em>
+      </p>
+
+      <p className="mt-12 text-sm text-gray-600">Last updated: 19 May 2026.</p>
+
+      {/*
+        --------------------------------------------------------------------
+        APPLE PRIVACY NUTRITION LABEL MAPPING (paste into App Store Connect):
+        --------------------------------------------------------------------
+        - Data Used to Track You: None
+        - Data Linked to You:
+            * Contact Info — email address, name
+            * User Content — none (we do not host user-generated content beyond
+              organiser-submitted events, which are public business listings)
+            * Identifiers — User ID (account identifier)
+            * Purchases — purchase history (in-app purchases, subscriptions)
+            * Location — Precise Location, Coarse Location (both optional, user
+              must grant permission)
+            * Usage Data — Product Interaction (categories viewed, events viewed)
+        - Data Not Linked to You:
+            * Diagnostics — Crash Data, Performance Data (if/when added; today
+              the app does not ship a dedicated analytics SDK — confirm before
+              filing)
+        - Data Used to Track You: None
+
+        --------------------------------------------------------------------
+        GOOGLE PLAY DATA SAFETY MAPPING (paste into Play Console):
+        --------------------------------------------------------------------
+        - Personal info:
+            * Name              — collected, linked, REQUIRED
+            * Email address     — collected, linked, REQUIRED
+            * User IDs          — collected, linked, REQUIRED
+        - Location:
+            * Approximate location — collected, linked, OPTIONAL
+            * Precise location     — collected, linked, OPTIONAL
+        - Financial info:
+            * Purchase history — collected (handled by Google Play Billing /
+              Apple App Store; we receive a receipt only)
+        - App activity:
+            * App interactions  — collected, linked  (categories selected,
+              events viewed)
+            * Other actions     — collected, linked  (favourites, lists)
+        - App info and performance:
+            * Crash logs        — collected (if/when a crash SDK is added —
+              confirm before filing)
+            * Diagnostics       — collected (general request logs for support)
+        - Device or other IDs:
+            * Account-level user ID — collected, linked
+        - Security practices:
+            * Data is encrypted in transit:  YES (HTTPS / TLS to api.godo-dev.nu)
+            * Data is encrypted at rest:     YES (GleSYS managed encryption)
+            * Users can request data deletion: YES — in-app: Profile → Delete
+              Account; or by emailing privacy@godo.nu
+            * Does the app follow Play Families Policy?  NOT a Families app
+              (minimum age 16)
+            * Has the app been independently validated against a global
+              security standard?  NO (confirm with counsel before filing)
+      */}
+    </>
+  );
+}

--- a/src/components/legal/PrivacyPolicySv.tsx
+++ b/src/components/legal/PrivacyPolicySv.tsx
@@ -1,0 +1,456 @@
+/**
+ * Swedish-language Privacy Policy content.
+ *
+ * Authored as a strong DRAFT. All values still pending legal review are
+ * flagged with `<!-- TODO: confirm ... -->` in JSX comments and rendered
+ * as visible "[TBD]" markers so legal counsel can locate them on a
+ * printed/exported copy. Tone uses "du" to match the rest of the site.
+ */
+export function PrivacyPolicySv() {
+  return (
+    <>
+      <h1 className="text-3xl font-bold mb-2">Integritetspolicy</h1>
+      <p className="text-sm text-gray-600 mb-8">
+        Gäller från: 19 maj 2026 · Senast uppdaterad: 19 maj 2026
+      </p>
+
+      <p>
+        Den här integritetspolicyn beskriver hur <strong>Go.Do AB</strong> (&quot;Go.Do&quot;,
+        &quot;vi&quot;, &quot;oss&quot;) samlar in, använder och skyddar dina personuppgifter
+        när du använder Go.Do mobilapp (iOS och Android, paket{" "}
+        <code>nu.godo.app</code>), arrangörswebbplatsen{" "}
+        <a href="https://godo-dev.nu" className="underline">
+          godo-dev.nu
+        </a>{" "}
+        samt våra backend-tjänster (tillsammans &quot;Tjänsten&quot;).
+      </p>
+
+      <p>
+        Go.Do AB är <strong>personuppgiftsansvarig</strong> för behandlingen av de
+        personuppgifter som beskrivs i denna policy, i enlighet med EU:s allmänna
+        dataskyddsförordning (förordning (EU) 2016/679, &quot;GDPR&quot;) och
+        dataskyddslagen (2018:218).
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">1. Vilka vi är</h2>
+      <p>
+        <strong>Go.Do AB</strong>
+        <br />
+        Sverige
+        <br />
+        {/* TODO: confirm SV legal registered address */}
+        Registrerad adress: <em>[Att fastställas — väntar på juridiskt ombud]</em>
+        <br />
+        {/* TODO: confirm SV organisation number */}
+        Organisationsnummer: <em>[Att fastställas — väntar på juridiskt ombud]</em>
+        <br />
+        Kontakt i integritetsfrågor:{" "}
+        <a href="mailto:privacy@godo.nu" className="underline">
+          privacy@godo.nu
+        </a>
+      </p>
+      <p>
+        {/* TODO: confirm whether a formal DPO (dataskyddsombud) is appointed */}
+        Vi har utsett en kontaktperson för integritetsfrågor som ansvarar för att besvara
+        frågor om denna policy. Hör av dig till adressen ovan om du har frågor eller vill
+        utöva dina lagstadgade rättigheter.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">2. Vilka uppgifter vi samlar in</h2>
+      <p>Vi samlar bara in de uppgifter vi behöver för att driva Tjänsten:</p>
+
+      <h3 className="mt-6">2.1 Kontouppgifter</h3>
+      <ul>
+        <li>
+          <strong>E-postadress</strong> — krävs för att skapa konto, logga in och ta emot
+          nödvändiga servicemejl (lösenordsåterställning, kontomeddelanden).
+        </li>
+        <li>
+          <strong>Namn</strong> — krävs vid registrering och visas i din profil.
+        </li>
+        <li>
+          <strong>Lösenord</strong> (om du registrerade dig med e-post och lösenord) — lagras
+          som en saltad hash med HMAC-SHA512 och unikt salt per användare. Vi lagrar aldrig
+          lösenord i klartext och vi ser aldrig ditt lösenord. Konton som skapats enbart via
+          sociala inloggningar (Apple eller Google) har inget lösenord alls.
+        </li>
+        <li>
+          <strong>Roll</strong> — om du är vanlig användare, arrangör eller administratör.
+          Detta styr vilka funktioner du har åtkomst till.
+        </li>
+      </ul>
+
+      <h3 className="mt-6">2.2 Inloggningsleverantörer (social inloggning)</h3>
+      <p>
+        Om du loggar in med Google eller Apple får vi en stabil identifierare och din
+        e-postadress från leverantören. Vi får <strong>aldrig</strong> ditt
+        sociala-medie-lösenord.
+      </p>
+      <ul>
+        <li>
+          <strong>Google Sign-In</strong> via Googles officiella bibliotek (mobil:{" "}
+          <code>@react-native-google-signin/google-signin</code>).
+        </li>
+        <li>
+          <strong>Logga in med Apple</strong> via <code>expo-apple-authentication</code>.
+          Apple kan returnera en s.k. privat relay-e-postadress; vi behandlar den på samma
+          sätt som en vanlig e-postadress.
+        </li>
+      </ul>
+
+      <h3 className="mt-6">2.3 Platsdata (valfritt)</h3>
+      <p>
+        Med ditt samtycke kan mobilappen använda din <strong>ungefärliga</strong> eller{" "}
+        <strong>exakta</strong> position för att visa evenemang nära dig och placera dig på
+        kartan. Du kan ge eller dra tillbaka detta samtycke när som helst i enhetens
+        inställningar. Tjänsten fungerar även utan plats — då väljer du stad manuellt.
+      </p>
+
+      <h3 className="mt-6">2.4 Kalenderåtkomst (valfritt)</h3>
+      <p>
+        Med ditt samtycke kan mobilappen läsa och skriva i enhetens kalender, så att du kan
+        lägga till ett intressant evenemang i din egen kalender med en knapptryckning. Vi
+        skickar inte innehållet i din kalender till våra servrar — läs/skriv sker lokalt på
+        din enhet.
+      </p>
+
+      <h3 className="mt-6">2.5 Köp i appen och prenumerationer</h3>
+      <p>
+        Premiumfunktioner (t.ex. Spotlight-marknadsföring och Premium-prenumerationer)
+        faktureras via <strong>Apple App Store</strong> (köp i appen) eller{" "}
+        <strong>Google Play Billing</strong>. Apple och Google hanterar betalningen och vi
+        ser <strong>aldrig ditt kortnummer eller fullständiga betalningsuppgifter</strong>.
+        Vi får endast:
+      </p>
+      <ul>
+        <li>Ett kvitto eller token som vi validerar serverside för att bekräfta köpet.</li>
+        <li>Produkt-id för det du köpt (t.ex. premium-nivå).</li>
+        <li>Köp- och förnyelsestatus så att vi kan ge eller dra in åtkomst.</li>
+      </ul>
+
+      <h3 className="mt-6">2.6 Inloggningstokens på din enhet</h3>
+      <p>
+        Efter inloggning lagrar vi en kortlivad access-token (ungefär 5 minuter) och en
+        refresh-token i enhetens säkra lagring (iOS Keychain / Android Keystore, via{" "}
+        <code>expo-secure-store</code>). Dessa tokens stannar på din enhet och skickas
+        endast till vårt API när du gör en förfrågan.
+      </p>
+
+      <h3 className="mt-6">2.7 Användardata</h3>
+      <p>
+        Vi registrerar översiktligt hur Tjänsten används — vilka evenemang som visas, vilka
+        kategorier och filter som väljs och liknande produktanalys. Vi använder detta för
+        att förbättra Tjänsten. Vi säljer inte data och använder den inte för spårning
+        mellan appar.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">3. Hur vi använder dina uppgifter</h2>
+      <table className="my-4 border-collapse">
+        <thead>
+          <tr className="text-left">
+            <th className="border p-2">Typ av uppgift</th>
+            <th className="border p-2">Ändamål</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border p-2">E-post, namn, lösenords-hash</td>
+            <td className="border p-2">Skapa och skydda ditt konto; logga in dig.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Social inloggnings-id</td>
+            <td className="border p-2">Logga in dig via Apple eller Google.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Plats</td>
+            <td className="border p-2">Visa evenemang nära dig; sortera efter avstånd.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Kalenderåtkomst</td>
+            <td className="border p-2">Lägg till valda evenemang i din enhets kalender.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Köpkvitton</td>
+            <td className="border p-2">Aktivera betalda funktioner; hantera återbetalningar.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Inloggningstokens</td>
+            <td className="border p-2">Hålla dig säkert inloggad mellan sessioner.</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Användardata</td>
+            <td className="border p-2">Förbättra Tjänsten, åtgärda buggar, prioritera nya funktioner.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">4. Rättsliga grunder (GDPR artikel 6)</h2>
+      <ul>
+        <li>
+          <strong>Fullgörande av avtal</strong> (art. 6.1 b) — för att skapa ditt konto,
+          leverera Tjänsten du registrerat dig för och hantera köp.
+        </li>
+        <li>
+          <strong>Berättigat intresse</strong> (art. 6.1 f) — för att driva, säkra och
+          förbättra Tjänsten (t.ex. bedrägeriskydd, grundläggande produktanalys). Vi gör
+          alltid en avvägning mot dina rättigheter och friheter.
+        </li>
+        <li>
+          <strong>Samtycke</strong> (art. 6.1 a) — för valfria funktioner som kräver
+          tillstånd, t.ex. plats- och kalenderåtkomst. Du kan när som helst dra tillbaka
+          samtycket, utan att det påverkar lagligheten av tidigare behandling.
+        </li>
+        <li>
+          <strong>Rättslig förpliktelse</strong> (art. 6.1 c) — där vi enligt lag måste
+          spara uppgifter, t.ex. bokföringsmaterial enligt bokföringslagen (1999:1078).
+        </li>
+      </ul>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">5. Delning och personuppgiftsbiträden</h2>
+      <p>
+        Vi säljer inte dina personuppgifter. Vi delar uppgifter endast med leverantörer
+        (&quot;personuppgiftsbiträden&quot;) som behövs för att driva Tjänsten. Varje
+        biträde behandlar uppgifter enligt våra instruktioner under ett
+        biträdesavtal/personuppgiftsbiträdesavtal (DPA).
+      </p>
+      <table className="my-4 border-collapse">
+        <thead>
+          <tr className="text-left">
+            <th className="border p-2">Leverantör</th>
+            <th className="border p-2">Ändamål</th>
+            <th className="border p-2">Plats</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border p-2">Apple Inc.</td>
+            <td className="border p-2">
+              Distribution av iOS-app, Logga in med Apple, köp i appen via App Store.
+            </td>
+            <td className="border p-2">USA / globalt</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Google LLC</td>
+            <td className="border p-2">
+              Distribution via Google Play, Google Sign-In, Google Maps (kartor för
+              evenemang), Play Billing.
+            </td>
+            <td className="border p-2">USA / globalt</td>
+          </tr>
+          <tr>
+            <td className="border p-2">GleSYS AB</td>
+            <td className="border p-2">
+              Primär infrastruktur (servrar, databas, säkerhetskopior).
+            </td>
+            <td className="border p-2">Sverige (EU)</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Resend</td>
+            <td className="border p-2">
+              Transaktionsmejl (lösenordsåterställning, kontomeddelanden).
+            </td>
+            <td className="border p-2">USA / EU</td>
+          </tr>
+          <tr>
+            <td className="border p-2">Expo / EAS (Expo Inc.)</td>
+            <td className="border p-2">
+              Build- och OTA-uppdateringsverktyg för mobilen. Inga personuppgifter om
+              slutanvändare skickas av Tjänsten till Expo.
+            </td>
+            <td className="border p-2">USA</td>
+          </tr>
+        </tbody>
+      </table>
+      {/* TODO: confirm any other subprocessors */}
+      <p className="text-xs text-gray-500">
+        [Att fastställas — juridiskt ombud bekräftar om ytterligare biträden används
+        (analytics, felrapportering, push-notiser m.m.).]
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">6. Överföringar utanför EES</h2>
+      <p>
+        De flesta personuppgifter behandlas på servrar i <strong>Sverige</strong> (EU/EES).
+        Vissa biträden (särskilt Apple, Google, Resend och Expo) kan dock överföra eller
+        komma åt personuppgifter utanför EES — typiskt sett till USA. När det sker
+        tillämpar vi EU-kommissionens standardavtalsklausuler (SCC) och, vid behov,
+        ytterligare skyddsåtgärder enligt GDPR artikel 44–49.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">7. Lagringstid</h2>
+      {/* TODO: confirm retention periods */}
+      <ul>
+        <li>
+          <strong>Aktiva konton</strong> — så länge ditt konto finns.
+        </li>
+        <li>
+          <strong>Raderade konton</strong> — personuppgifter raderas eller anonymiseras
+          inom <em>[Att fastställas — föreslaget: 30 dagar]</em> efter att du raderat ditt
+          konto, utom där lag kräver att vi sparar vissa uppgifter.
+        </li>
+        <li>
+          <strong>Köp- och bokföringsunderlag</strong> — sparas i{" "}
+          <em>[Att fastställas — föreslaget: 7 år]</em> enligt bokföringslagen
+          (1999:1078).
+        </li>
+        <li>
+          <strong>Serverloggar</strong> — sparas i{" "}
+          <em>[Att fastställas — föreslaget: 90 dagar]</em> för säkerhet och felsökning.
+        </li>
+        <li>
+          <strong>Säkerhetskopior</strong> — krypterade säkerhetskopior roteras ut inom{" "}
+          <em>[Att fastställas — föreslaget: 30 dagar]</em>.
+        </li>
+      </ul>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">8. Dina rättigheter</h2>
+      <p>Enligt GDPR (artikel 15–22) har du rätt att:</p>
+      <ul>
+        <li>
+          <strong>Få tillgång till</strong> de personuppgifter vi har om dig (art. 15).
+        </li>
+        <li>
+          <strong>Rätta</strong> felaktiga eller ofullständiga uppgifter (art. 16).
+        </li>
+        <li>
+          <strong>Radera</strong> dina uppgifter (&quot;rätten att bli glömd&quot;, art.
+          17). Du kan göra detta själv i appen — se avsnitt 9.
+        </li>
+        <li>
+          <strong>Begränsa behandlingen</strong> av dina uppgifter (art. 18).
+        </li>
+        <li>
+          {/* TODO: confirm SV term — "dataportabilitet" is the established term */}
+          <strong>Dataportabilitet</strong> — få ut dina uppgifter i ett maskinläsbart
+          format (art. 20).
+        </li>
+        <li>
+          <strong>Invända</strong> mot behandling baserad på berättigat intresse (art. 21).
+        </li>
+        <li>
+          <strong>Dra tillbaka samtycke</strong> när som helst, där behandlingen är
+          baserad på samtycke (art. 7.3).
+        </li>
+        <li>
+          <strong>Klaga</strong> hos den svenska tillsynsmyndigheten,{" "}
+          <strong>Integritetsskyddsmyndigheten (IMY)</strong> —{" "}
+          <a href="https://www.imy.se" className="underline">
+            imy.se
+          </a>{" "}
+          — eller hos tillsynsmyndigheten i ditt hemland inom EU.
+        </li>
+      </ul>
+      <p>
+        Skicka ett mejl till{" "}
+        <a href="mailto:privacy@godo.nu" className="underline">
+          privacy@godo.nu
+        </a>{" "}
+        för att utöva någon av dessa rättigheter. Vi svarar inom en månad (med möjlighet
+        till ytterligare två månader för komplexa ärenden, enligt GDPR art. 12.3).
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">9. Radera kontot</h2>
+      <p>Du kan radera ditt Go.Do-konto när som helst, direkt i mobilappen:</p>
+      <ol>
+        <li>Öppna Go.Do-appen och logga in.</li>
+        <li>
+          Gå till fliken <strong>Profil</strong>.
+        </li>
+        <li>
+          Tryck på <strong>Radera konto</strong> och bekräfta.
+        </li>
+      </ol>
+      <p>
+        När du bekräftar schemaläggs kontot för radering. Personuppgifter tas bort eller
+        anonymiseras enligt reglerna i avsnitt 7. Vissa uppgifter (särskilt köp- och
+        bokföringsunderlag) måste enligt lag sparas under en viss tid och raderas därefter.
+      </p>
+      <p>
+        Om du av någon anledning inte kommer åt appen, mejla{" "}
+        <a href="mailto:privacy@godo.nu" className="underline">
+          privacy@godo.nu
+        </a>{" "}
+        från den e-postadress som är kopplad till ditt konto, så hanterar vi raderingen åt
+        dig.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">10. Barns integritet</h2>
+      {/* TODO: confirm minimum age — default 16 to align with GDPR art. 8 */}
+      <p>
+        Tjänsten riktar sig inte till barn under <strong>16</strong> år. Vi samlar inte
+        medvetet in personuppgifter från barn under 16. Om du är vårdnadshavare och tror
+        att ditt barn har lämnat personuppgifter till oss, kontakta oss så raderar vi
+        uppgifterna.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">11. Säkerhet</h2>
+      <ul>
+        <li>All kommunikation med vårt API är krypterad via <strong>HTTPS (TLS)</strong>.</li>
+        <li>
+          Lösenord lagras som <strong>HMAC-SHA512-hashar med unikt salt per användare</strong>
+          . Vi loggar eller sparar aldrig lösenord i klartext.
+        </li>
+        <li>
+          Köpkvitton valideras <strong>serverside</strong> mot Apple och Google — klienter
+          kan inte aktivera betalda funktioner själva.
+        </li>
+        <li>
+          Access-tokens på din enhet lagras i operativsystemets säkra lagring (iOS
+          Keychain / Android Keystore).
+        </li>
+        <li>
+          Vi begränsar intern åtkomst till personuppgifter enligt principen om minsta
+          behörighet och granskar åtkomst regelbundet.
+        </li>
+      </ul>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">12. Ändringar i denna policy</h2>
+      <p>
+        Vi kan komma att uppdatera denna integritetspolicy. När vi gör väsentliga
+        ändringar uppdaterar vi datumet &quot;Senast uppdaterad&quot; överst på sidan och
+        informerar dig vid behov i appen eller via e-post. Om du fortsätter att använda
+        Tjänsten efter en ändring innebär det att du accepterar den uppdaterade policyn.
+        Vi rekommenderar att du läser sidan regelbundet.
+      </p>
+
+      {/* ---------------------------------------------------------------- */}
+      <h2 className="mt-10">13. Kontakt</h2>
+      <p>
+        För integritetsrelaterade frågor eller för att utöva någon av rättigheterna
+        ovan, kontakta:
+        <br />
+        <strong>Go.Do AB</strong>
+        <br />
+        <a href="mailto:privacy@godo.nu" className="underline">
+          privacy@godo.nu
+        </a>
+        <br />
+        {/* TODO: confirm SV legal postal address */}
+        <em>[Postadress att fastställas — väntar på juridiskt ombud]</em>
+      </p>
+
+      <p className="mt-12 text-sm text-gray-600">Senast uppdaterad: 19 maj 2026.</p>
+
+      {/*
+        --------------------------------------------------------------------
+        APPLE PRIVACY NUTRITION LABEL MAPPING (paste into App Store Connect):
+        --------------------------------------------------------------------
+        See the English version (/privacy) for the canonical mapping that
+        the user pastes into App Store Connect and Google Play Console.
+        Console UIs are English-only, so we keep the mapping single-sourced
+        on the English page to avoid drift.
+      */}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a public, bilingual **Privacy Policy** at `/privacy` (English) and `/sv/privacy` (Swedish), required for App Store + Google Play submission of the Go.Do mobile app. The page covers the mobile app (`nu.godo.app`), the organiser website (`godo-dev.nu`), and backend services, with Go.Do AB named as data controller.

The pages are marked **DRAFT** with a yellow banner at the top and `<!-- TODO: confirm ... -->` comments inline for legal counsel to resolve before public launch.

### What's in
- `/privacy` and `/sv/privacy` (Server Components, static, hreflang-aware metadata)
- Shared `LegalLayout` + `DraftBanner` components in `src/components/legal/`
- New site-wide `Footer` linking both language versions, dropped onto the landing page
- Registration "I agree to terms" checkbox now links to `/privacy`
- `robots.ts` + `sitemap.ts` metadata routes (sitemap declares hreflang alternates)
- Apple Privacy Nutrition Label + Google Play Data Safety form mappings embedded as HTML comments at the bottom of `PrivacyPolicyEn.tsx` for copy-paste into the consoles

### Content sections (both languages)
Who we are · What we collect (account info incl. HMAC-SHA512 password hashing, Apple/Google sign-in, location, calendar, IAP receipts, secure-store tokens, usage data) · How we use it · GDPR legal bases (Art. 6) · Subprocessors (Apple, Google, GleSYS, Resend, Expo) · International transfers (SCCs) · Retention · GDPR rights (Art. 15–22) · Account deletion (Profile → Delete Account) · Children (16+) · Security · Changes · Contact

### TODO markers for counsel
Registered legal address · Swedish org number · whether a formal DPO is appointed · additional subprocessors (analytics/error tracking/push) · retention periods · minimum-age policy · Swedish term confirmations · legal postal address

### Design decisions
- **No new i18n library.** Repo had zero i18n; used a simple `/sv/*` folder rather than pulling in `next-intl`. Easy to migrate later.
- **Single source of truth** for Apple/Google form mappings (English page only) to avoid drift — both consoles are English-only anyway.

## Verification
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — green; `/privacy`, `/sv/privacy`, `/robots.txt`, `/sitemap.xml` all prerendered as static

## Test plan
- [ ] Visit `/privacy` and `/sv/privacy` locally — banner shows, language switcher works
- [ ] Visit `/landing` — footer renders with both privacy links
- [ ] Visit `/register` — terms checkbox links to `/privacy` in a new tab
- [ ] `curl https://godo-dev.nu/robots.txt` and `/sitemap.xml` after deploy
- [ ] Counsel review of the DRAFT content; resolve all `<!-- TODO -->` markers
- [ ] Paste URL into App Store Connect → App Privacy → Privacy Policy URL
- [ ] Paste URL into Google Play Console → App content → Privacy Policy
- [ ] Use the comment-block mapping to fill the Apple Nutrition Label + Google Data Safety form

🤖 Generated with [Claude Code](https://claude.com/claude-code)