### PR TITLE
style: brand & UI polish (#65)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Visual Studio IDE metadata
+.vs/
+
 # dependencies
 /node_modules
 /.pnp

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -45,7 +45,7 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
+    <main className="min-h-screen flex flex-col bg-brand text-black">
       <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
         <div className="text-center lg:text-left shrink-0">
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold mb-2 lg:mb-4">Go.Do.</h2>

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -45,7 +45,7 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-yellow-400 text-black">
+    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
       <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
         <div className="text-center lg:text-left shrink-0">
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold mb-2 lg:mb-4">Go.Do.</h2>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -59,7 +59,7 @@ export default function LoginPage() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
+    <main className="min-h-screen flex flex-col bg-brand text-black">
       <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
         {/* Branding — stacks above card on mobile, sits left on desktop */}
         <div className="text-center lg:text-left shrink-0">
@@ -133,7 +133,7 @@ export default function LoginPage() {
               <div className="w-full pt-2 border-t border-black/10">
                 <Link
                   href="/preview"
-                  className="flex items-center justify-center gap-2 w-full py-2.5 rounded-lg bg-[#F3C10E] text-black text-sm font-semibold hover:brightness-95 transition-colors"
+                  className="flex items-center justify-center gap-2 w-full py-2.5 rounded-lg bg-brand text-black text-sm font-semibold hover:brightness-95 transition-colors"
                 >
                   See the app in action
                   <span aria-hidden="true">&rarr;</span>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -59,7 +59,7 @@ export default function LoginPage() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-yellow-400 text-black">
+    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
       <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
         {/* Branding — stacks above card on mobile, sits left on desktop */}
         <div className="text-center lg:text-left shrink-0">
@@ -133,7 +133,7 @@ export default function LoginPage() {
               <div className="w-full pt-2 border-t border-black/10">
                 <Link
                   href="/preview"
-                  className="flex items-center justify-center gap-2 w-full py-2.5 rounded-lg bg-yellow-400 text-black text-sm font-semibold hover:bg-yellow-300 transition-colors"
+                  className="flex items-center justify-center gap-2 w-full py-2.5 rounded-lg bg-[#F3C10E] text-black text-sm font-semibold hover:brightness-95 transition-colors"
                 >
                   See the app in action
                   <span aria-hidden="true">&rarr;</span>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -104,7 +104,7 @@ export default function OrganizerRegisterPage() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-yellow-400 text-black">
+    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
       <section className="flex flex-1 items-center justify-center px-6 md:px-10 py-14 md:py-20 relative">
         <div className="hidden md:block absolute left-20 top-1/2 -translate-y-1/2">
           <h2 className="text-6xl font-extrabold mb-4">Go.Do.</h2>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -104,7 +104,7 @@ export default function OrganizerRegisterPage() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
+    <main className="min-h-screen flex flex-col bg-brand text-black">
       <section className="flex flex-1 items-center justify-center px-6 md:px-10 py-14 md:py-20 relative">
         <div className="hidden md:block absolute left-20 top-1/2 -translate-y-1/2">
           <h2 className="text-6xl font-extrabold mb-4">Go.Do.</h2>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -62,7 +62,7 @@ function ResetPasswordInner() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-yellow-400 text-black">
+    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
       <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
         <div className="text-center lg:text-left shrink-0">
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold mb-2 lg:mb-4">Go.Do.</h2>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -62,7 +62,7 @@ function ResetPasswordInner() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
+    <main className="min-h-screen flex flex-col bg-brand text-black">
       <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
         <div className="text-center lg:text-left shrink-0">
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold mb-2 lg:mb-4">Go.Do.</h2>

--- a/src/app/(auth)/users/reset-password/page.tsx
+++ b/src/app/(auth)/users/reset-password/page.tsx
@@ -61,7 +61,7 @@ function UserResetPasswordInner() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
+    <main className="min-h-screen flex flex-col bg-brand text-black">
       <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
         <div className="text-center lg:text-left shrink-0">
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold mb-2 lg:mb-4">Go.Do.</h2>

--- a/src/app/(auth)/users/reset-password/page.tsx
+++ b/src/app/(auth)/users/reset-password/page.tsx
@@ -61,7 +61,7 @@ function UserResetPasswordInner() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-yellow-400 text-black">
+    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
       <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
         <div className="text-center lg:text-left shrink-0">
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold mb-2 lg:mb-4">Go.Do.</h2>

--- a/src/app/(auth)/users/verify-email/page.tsx
+++ b/src/app/(auth)/users/verify-email/page.tsx
@@ -79,7 +79,7 @@ function VerifyEmailInner() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
+    <main className="min-h-screen flex flex-col bg-brand text-black">
       <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
         <div className="text-center lg:text-left shrink-0">
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold mb-2 lg:mb-4">Go.Do.</h2>

--- a/src/app/(auth)/users/verify-email/page.tsx
+++ b/src/app/(auth)/users/verify-email/page.tsx
@@ -79,7 +79,7 @@ function VerifyEmailInner() {
   };
 
   return (
-    <main className="min-h-screen flex flex-col bg-yellow-400 text-black">
+    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
       <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
         <div className="text-center lg:text-left shrink-0">
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold mb-2 lg:mb-4">Go.Do.</h2>

--- a/src/app/create-event/page.tsx
+++ b/src/app/create-event/page.tsx
@@ -39,6 +39,7 @@ const steps = [
 
 export default function CreateEventPage() {
   const [step, setStep] = useState(0);
+  const [maxStep, setMaxStep] = useState(0);
   const [formSubmitted, setFormSubmitted] = useState(false);
   const [submittedData, setSubmittedData] = useState<CreateEventFormData | null>(null);
 
@@ -55,6 +56,7 @@ export default function CreateEventPage() {
   const handleCreateAnother = () => {
     form.reset(defaultFormValues);
     setStep(0);
+    setMaxStep(0);
     setFormSubmitted(false);
     setSubmittedData(null);
   };
@@ -62,7 +64,12 @@ export default function CreateEventPage() {
   const totalSteps = steps.length;
   const lastIndex = totalSteps - 1;
 
-  const nextStep = () => setStep((s) => Math.min(s + 1, lastIndex));
+  const nextStep = () =>
+    setStep((s) => {
+      const next = Math.min(s + 1, lastIndex);
+      setMaxStep((m) => Math.max(m, next));
+      return next;
+    });
   const prevStep = () => setStep((s) => Math.max(s - 1, 0));
 
   const onSubmit = (data: CreateEventFormData) => {
@@ -111,7 +118,7 @@ export default function CreateEventPage() {
   };
 
   return (
-    <main className="min-h-screen bg-yellow-400 text-black flex flex-col">
+    <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
       <Navbar />
       <section className="flex-1 flex flex-col items-center px-6 py-10">
         <div className="w-full max-w-xl mb-4">
@@ -127,13 +134,17 @@ export default function CreateEventPage() {
         <div className="w-full max-w-xl mb-6">
           <div className="flex justify-between text-sm font-medium mb-2">
             {steps.map((stepObj, i) => (
-              <span
+              <button
                 key={i}
-                className={`flex items-center gap-1 ${i <= step ? "text-black" : "text-gray-500"}`}
+                type="button"
+                onClick={() => i !== step && i <= maxStep && setStep(i)}
+                className={`flex items-center gap-1 ${
+                  i <= maxStep ? "text-black" : "text-gray-500"
+                } ${i !== step && i <= maxStep ? "cursor-pointer hover:underline" : "cursor-default"}`}
               >
                 {stepObj.icon}
                 {stepObj.label}
-              </span>
+              </button>
             ))}
           </div>
           <div className="h-2 bg-gray-300 rounded-full">

--- a/src/app/create-event/page.tsx
+++ b/src/app/create-event/page.tsx
@@ -64,12 +64,11 @@ export default function CreateEventPage() {
   const totalSteps = steps.length;
   const lastIndex = totalSteps - 1;
 
-  const nextStep = () =>
-    setStep((s) => {
-      const next = Math.min(s + 1, lastIndex);
-      setMaxStep((m) => Math.max(m, next));
-      return next;
-    });
+  const nextStep = () => {
+    const next = Math.min(step + 1, lastIndex);
+    setStep(next);
+    setMaxStep((m) => Math.max(m, next));
+  };
   const prevStep = () => setStep((s) => Math.max(s - 1, 0));
 
   const onSubmit = (data: CreateEventFormData) => {
@@ -118,7 +117,7 @@ export default function CreateEventPage() {
   };
 
   return (
-    <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
+    <main className="min-h-screen bg-brand text-black flex flex-col">
       <Navbar />
       <section className="flex-1 flex flex-col items-center px-6 py-10">
         <div className="w-full max-w-xl mb-4">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -116,6 +116,9 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    scrollbar-gutter: stable;
+  }
   body {
     @apply bg-background text-foreground;
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,7 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
+  --color-brand: #F3C10E;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
     <main className="min-h-screen flex flex-col">
       <Navbar />
 
-      <section className="flex-1 flex justify-between items-center bg-[#F3C10E] text-black px-10 py-20 relative">
+      <section className="flex-1 flex justify-between items-center bg-brand text-black px-10 py-20 relative">
         {/* Left: Brand */}
         <div>
           <h2 className="text-6xl font-extrabold mb-4">Go.Do.</h2>

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
     <main className="min-h-screen flex flex-col">
       <Navbar />
 
-      <section className="flex-1 flex justify-between items-center bg-yellow-400 text-black px-10 py-20 relative">
+      <section className="flex-1 flex justify-between items-center bg-[#F3C10E] text-black px-10 py-20 relative">
         {/* Left: Brand */}
         <div>
           <h2 className="text-6xl font-extrabold mb-4">Go.Do.</h2>

--- a/src/app/my-events/[id]/edit/page.tsx
+++ b/src/app/my-events/[id]/edit/page.tsx
@@ -120,7 +120,7 @@ export default function EditEventPage() {
   // Loading state
   if (isLoadingEvent || !isFormReady) {
     return (
-      <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
+      <main className="min-h-screen bg-brand text-black flex flex-col">
         <Navbar />
         <section className="flex-1 flex items-center justify-center">
           <div className="flex flex-col items-center gap-4">
@@ -135,7 +135,7 @@ export default function EditEventPage() {
   // Error state
   if (eventError || !eventData?.isSuccess) {
     return (
-      <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
+      <main className="min-h-screen bg-brand text-black flex flex-col">
         <Navbar />
         <section className="flex-1 flex items-center justify-center">
           <div className="bg-white p-6 rounded-lg shadow text-center">
@@ -157,7 +157,7 @@ export default function EditEventPage() {
   }
 
   return (
-    <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
+    <main className="min-h-screen bg-brand text-black flex flex-col">
       <Navbar />
       <section className="flex-1 flex flex-col items-center px-6 py-10">
         <div className="w-full max-w-xl mb-4">

--- a/src/app/my-events/[id]/edit/page.tsx
+++ b/src/app/my-events/[id]/edit/page.tsx
@@ -120,7 +120,7 @@ export default function EditEventPage() {
   // Loading state
   if (isLoadingEvent || !isFormReady) {
     return (
-      <main className="min-h-screen bg-yellow-400 text-black flex flex-col">
+      <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
         <Navbar />
         <section className="flex-1 flex items-center justify-center">
           <div className="flex flex-col items-center gap-4">
@@ -135,7 +135,7 @@ export default function EditEventPage() {
   // Error state
   if (eventError || !eventData?.isSuccess) {
     return (
-      <main className="min-h-screen bg-yellow-400 text-black flex flex-col">
+      <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
         <Navbar />
         <section className="flex-1 flex items-center justify-center">
           <div className="bg-white p-6 rounded-lg shadow text-center">
@@ -157,7 +157,7 @@ export default function EditEventPage() {
   }
 
   return (
-    <main className="min-h-screen bg-yellow-400 text-black flex flex-col">
+    <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
       <Navbar />
       <section className="flex-1 flex flex-col items-center px-6 py-10">
         <div className="w-full max-w-xl mb-4">

--- a/src/app/my-events/page.tsx
+++ b/src/app/my-events/page.tsx
@@ -115,7 +115,7 @@ export default function MyEventsPage() {
 
   if (!userId) {
     return (
-      <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
+      <main className="min-h-screen bg-brand text-black flex flex-col">
         <Navbar />
         <div className="flex-1 flex items-center justify-center">
           <Loader2 className="w-8 h-8 animate-spin" />
@@ -125,7 +125,7 @@ export default function MyEventsPage() {
   }
 
   return (
-    <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
+    <main className="min-h-screen bg-brand text-black flex flex-col">
       <Navbar />
 
       <section className="flex-1 px-6 py-10 max-w-6xl mx-auto w-full">

--- a/src/app/my-events/page.tsx
+++ b/src/app/my-events/page.tsx
@@ -115,7 +115,7 @@ export default function MyEventsPage() {
 
   if (!userId) {
     return (
-      <main className="min-h-screen bg-yellow-400 text-black flex flex-col">
+      <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
         <Navbar />
         <div className="flex-1 flex items-center justify-center">
           <Loader2 className="w-8 h-8 animate-spin" />
@@ -125,7 +125,7 @@ export default function MyEventsPage() {
   }
 
   return (
-    <main className="min-h-screen bg-yellow-400 text-black flex flex-col">
+    <main className="min-h-screen bg-[#F3C10E] text-black flex flex-col">
       <Navbar />
 
       <section className="flex-1 px-6 py-10 max-w-6xl mx-auto w-full">

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -12,7 +12,7 @@ import Image from "next/image";
 
 export default function PreviewPage() {
   return (
-    <main className="min-h-screen flex flex-col bg-yellow-400 text-black">
+    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
       <Navbar />
 
       <section className="flex-1 flex flex-col lg:flex-row items-center justify-center gap-10 lg:gap-16 px-6 sm:px-10 py-10 lg:py-6">

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -12,7 +12,7 @@ import Image from "next/image";
 
 export default function PreviewPage() {
   return (
-    <main className="min-h-screen flex flex-col bg-[#F3C10E] text-black">
+    <main className="min-h-screen flex flex-col bg-brand text-black">
       <Navbar />
 
       <section className="flex-1 flex flex-col lg:flex-row items-center justify-center gap-10 lg:gap-16 px-6 sm:px-10 py-10 lg:py-6">

--- a/src/components/global/Navbar.tsx
+++ b/src/components/global/Navbar.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Search } from "lucide-react";
 import { useState, useEffect } from "react";
 import Image from "next/image";
+import Link from "next/link";
 
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/axios";
@@ -33,18 +34,13 @@ export function Navbar() {
   };
 
   return (
-    <header className="w-full border-b bg-white p-4">
+    <header className="w-full bg-[#F3C10E] p-4">
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         {/* Left: Logo + Text */}
-        <div className="flex items-center gap-3">
+        <Link href="/landing" className="flex items-center gap-3">
           <Image src="/images/godologo.png" alt="Logo" width={100} height={100} />
-          <div>
-            <h1 className="text-xl font-semibold border-b-2 border-black inline-block">Go.Do.</h1>
-            <p className="text-sm italic text-gray-600">
-              More to do. <span className="text-gray-500">Close to you.</span>
-            </p>
-          </div>
-        </div>
+          <h1 className="text-xl font-semibold border-b-2 border-black inline-block">Go.Do.</h1>
+        </Link>
 
         {/* Right: Search */}
         <div className="flex items-center gap-2">

--- a/src/components/global/Navbar.tsx
+++ b/src/components/global/Navbar.tsx
@@ -34,7 +34,7 @@ export function Navbar() {
   };
 
   return (
-    <header className="w-full bg-[#F3C10E] p-4">
+    <header className="w-full bg-brand p-4">
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         {/* Left: Logo + Text */}
         <Link href="/landing" className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- Navbar now uses exact brand yellow (`#F3C10E`) matching all page backgrounds
- Slogan "More to do" removed from navbar
- Logo click navigates to `/landing`
- All pages unified on brand color (was `bg-yellow-400` / `#facc15`, now `#F3C10E`)
- Progress bar steps are clickable — navigate to any previously reached step
- Fixed navbar layout shift when scrollbar appears/disappears

## Changes
Resolves all 4 tasks in issue #65 plus two follow-on improvements discovered during implementation: brand color alignment across all pages, and a scrollbar-gutter fix for the navbar shift bug.

## Test Plan
- [x] Lint passes
- [x] Type check passes
- [x] Build passes
- [ ] Navbar yellow matches page background visually
- [ ] Logo click returns to landing page
- [ ] Progress bar: advance to step 3, go back to step 1 — steps 2 and 3 remain clickable
- [ ] No layout shift when navigating between short and tall pages

## Cross-Repo Impact
None — UI-only changes, no API contract affected.

Closes #65

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>