### PR TITLE
feat(form): event form categories & subcategories polish (#66)

### DIFF
--- a/src/components/forms/steps/StepEventDetails.tsx
+++ b/src/components/forms/steps/StepEventDetails.tsx
@@ -7,12 +7,15 @@ import { Controller, FieldErrors, UseFormRegister, Control } from "react-hook-fo
 import { FormData } from "@/hooks/useEventForm";
 import { useState } from "react";
 import { categoryOptions, filterOptions, subcategoriesMap } from "@/lib/content/contentText";
+import { CATEGORY_COLORS } from "@/components/preview/constants";
 
 interface StepDetailsProps {
   register: UseFormRegister<FormData>;
   control: Control<FormData>;
   errors: FieldErrors<FormData>;
 }
+
+const MAX_CATEGORIES = 3;
 
 export function StepEventDetails({ register, control, errors }: StepDetailsProps) {
   const [openDropdown, setOpenDropdown] = useState<number | null>(null);
@@ -74,6 +77,9 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
         <Label className="py-2 block">
           Select Categories <span className="text-red-500">*</span>
         </Label>
+        <p className="text-xs text-muted-foreground mb-3">
+          Max {MAX_CATEGORIES} kategorier — klicka på en vald kategori för att öppna underkategorier
+        </p>
         <Controller
           name="categories"
           control={control}
@@ -81,107 +87,144 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
             <Controller
               name="subcategories"
               control={control}
-              render={({ field: subField }) => (
-                <div className="flex flex-col space-y-4">
-                  {Array.from({ length: Math.ceil(categoryOptions.length / 4) }).map(
-                    (_, rowIdx) => {
-                      const row = categoryOptions.slice(rowIdx * 4, rowIdx * 4 + 4);
-                      const openInThisRow = row.some((cat) => cat.code === openDropdown);
+              render={({ field: subField }) => {
+                const selectedCount = (catField.value ?? []).length;
+                const atLimit = selectedCount >= MAX_CATEGORIES;
 
-                      return (
-                        <div key={rowIdx} className="space-y-4">
-                          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                            {row.map(({ code, label, icon: Icon }) => {
-                              const isSelected = (catField.value ?? []).includes(code);
+                return (
+                  <div className="flex flex-col space-y-4">
+                    {Array.from({ length: Math.ceil(categoryOptions.length / 4) }).map(
+                      (_, rowIdx) => {
+                        const row = categoryOptions.slice(rowIdx * 4, rowIdx * 4 + 4);
+                        const openInThisRow = row.some((cat) => cat.code === openDropdown);
 
-                              const toggleCategory = () => {
-                                const current = catField.value ?? [];
-                                const newVal = isSelected
-                                  ? current.filter((c) => c !== code)
-                                  : [...current, code];
-                                catField.onChange(newVal);
-                                setOpenDropdown((prev) => (prev === code ? null : code));
-                              };
+                        return (
+                          <div key={rowIdx} className="space-y-4">
+                            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                              {row.map(({ code, label, icon: Icon }) => {
+                                const isSelected = (catField.value ?? []).includes(code);
 
-                              return (
-                                <button
-                                  key={code}
-                                  type="button"
-                                  onClick={toggleCategory}
-                                  className={cn(
-                                    "flex flex-col items-center justify-center p-4 rounded-xl w-full h-24 border transition-all",
-                                    isSelected
-                                      ? "bg-yellow-400 text-black border-yellow-600"
-                                      : "bg-white text-gray-700 border-gray-300 hover:bg-gray-100"
-                                  )}
-                                >
-                                  <Icon className="w-6 h-6 mb-2" />
-                                  <span className="text-xs font-medium text-center">{label}</span>
-                                </button>
-                              );
-                            })}
-                          </div>
-
-                          {openInThisRow && openDropdown !== null && (
-                            <div className="w-full bg-white border rounded-lg p-4 shadow">
-                              <p className="text-sm font-semibold mb-2 text-gray-700">
-                                {categoryOptions.find((c) => c.code === openDropdown)?.label}{" "}
-                                Subcategories
-                              </p>
-                              <div className="flex flex-wrap gap-2 max-h-48 overflow-y-auto scroll-smooth">
-                                {subcategoriesMap[openDropdown]?.map(
-                                  ({ code: subCode, label: subLabel, icon: SubIcon }) => {
-                                    const selected =
-                                      subField.value?.[openDropdown]?.includes(subCode) ?? false;
-                                    return (
-                                      <button
-                                        key={subCode}
-                                        type="button"
-                                        onClick={() =>
-                                          toggleSubcategory(
-                                            subField.value,
-                                            subField.onChange,
-                                            openDropdown,
-                                            subCode
-                                          )
-                                        }
-                                        className={cn(
-                                          "flex flex-col items-center justify-center w-20 h-20 text-xs border rounded-lg transition p-2",
-                                          selected
-                                            ? "bg-yellow-300 border-yellow-500"
-                                            : "bg-white hover:bg-gray-100 border-gray-300"
-                                        )}
-                                      >
-                                        <SubIcon className="w-4 h-4 mb-1" />
-                                        <span className="text-center">{subLabel}</span>
-                                      </button>
-                                    );
+                                const handleClick = () => {
+                                  if (isSelected) {
+                                    if (openDropdown === code) {
+                                      // Second click on open tile → deselect + close
+                                      catField.onChange(
+                                        (catField.value ?? []).filter((c) => c !== code)
+                                      );
+                                      setOpenDropdown(null);
+                                    } else {
+                                      // First click on selected tile → open dropdown
+                                      setOpenDropdown(code);
+                                    }
+                                  } else if (!atLimit) {
+                                    catField.onChange([...(catField.value ?? []), code]);
+                                    setOpenDropdown(code);
                                   }
-                                )}
-                              </div>
-                              <div className="flex justify-center mt-4">
-                                <Button
-                                  variant="outline"
-                                  size="lg"
-                                  className="text-sm font-semibold px-6 py-2 border-yellow-500 text-yellow-700 hover:bg-yellow-100"
-                                  onClick={() =>
-                                    toggleAllSubs(subField.value, subField.onChange, openDropdown)
-                                  }
-                                >
-                                  {subField.value?.[openDropdown]?.length ===
-                                  subcategoriesMap[openDropdown]?.length
-                                    ? "Unselect All"
-                                    : "Select All"}
-                                </Button>
-                              </div>
+                                };
+
+                                return (
+                                  <button
+                                    key={code}
+                                    type="button"
+                                    onClick={handleClick}
+                                    disabled={!isSelected && atLimit}
+                                    style={{
+                                      backgroundColor: CATEGORY_COLORS[code],
+                                      boxShadow: isSelected
+                                        ? `0 0 0 3px white, 0 0 0 6px ${CATEGORY_COLORS[code]}`
+                                        : "none",
+                                      opacity: !isSelected && atLimit ? 0.35 : 1,
+                                    }}
+                                    className={cn(
+                                      "flex flex-col items-center justify-center p-4 rounded-xl w-full h-24 border-0 transition-all text-white",
+                                      !isSelected && atLimit ? "cursor-not-allowed" : ""
+                                    )}
+                                  >
+                                    <Icon className="w-6 h-6 mb-2" />
+                                    <span className="text-xs font-medium text-center">
+                                      {label}
+                                    </span>
+                                  </button>
+                                );
+                              })}
                             </div>
-                          )}
-                        </div>
-                      );
-                    }
-                  )}
-                </div>
-              )}
+
+                            {openInThisRow && openDropdown !== null && (
+                              <div className="w-full bg-white border rounded-lg p-4 shadow">
+                                <p className="text-sm font-semibold mb-2 text-gray-700">
+                                  {categoryOptions.find((c) => c.code === openDropdown)?.label}{" "}
+                                  Subcategories
+                                </p>
+                                <div className="flex flex-wrap gap-3 max-h-48 overflow-y-auto scroll-smooth p-1.5">
+                                  {subcategoriesMap[openDropdown]?.map(
+                                    ({ code: subCode, label: subLabel }) => {
+                                      const selected =
+                                        subField.value?.[openDropdown]?.includes(subCode) ?? false;
+                                      const catColor = CATEGORY_COLORS[openDropdown];
+                                      return (
+                                        <button
+                                          key={subCode}
+                                          type="button"
+                                          onClick={() =>
+                                            toggleSubcategory(
+                                              subField.value,
+                                              subField.onChange,
+                                              openDropdown,
+                                              subCode
+                                            )
+                                          }
+                                          style={{
+                                            backgroundColor: catColor,
+                                            boxShadow: selected
+                                              ? `0 0 0 2px white, 0 0 0 4px ${catColor}`
+                                              : "none",
+                                            opacity: selected ? 1 : 0.65,
+                                          }}
+                                          className={cn(
+                                            "px-3 py-1.5 text-xs border-0 rounded-full transition text-white",
+                                            selected ? "font-medium" : ""
+                                          )}
+                                        >
+                                          {subLabel}
+                                        </button>
+                                      );
+                                    }
+                                  )}
+                                </div>
+                                <div className="flex justify-center mt-4">
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="lg"
+                                    className="text-sm font-semibold px-6 py-2 border-yellow-500 text-yellow-700 hover:bg-yellow-100"
+                                    onClick={() =>
+                                      toggleAllSubs(
+                                        subField.value,
+                                        subField.onChange,
+                                        openDropdown
+                                      )
+                                    }
+                                  >
+                                    {subField.value?.[openDropdown]?.length ===
+                                    subcategoriesMap[openDropdown]?.length
+                                      ? "Unselect All"
+                                      : "Select All"}
+                                  </Button>
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      }
+                    )}
+                    {atLimit && (
+                      <p className="text-xs text-amber-600 font-medium">
+                        Max {MAX_CATEGORIES} kategorier valda — avmarkera en för att välja en annan
+                      </p>
+                    )}
+                  </div>
+                );
+              }}
             />
           )}
         />

--- a/src/components/forms/steps/StepEventDetails.tsx
+++ b/src/components/forms/steps/StepEventDetails.tsx
@@ -6,8 +6,7 @@ import { cn } from "@/lib/utils";
 import { Controller, FieldErrors, UseFormRegister, Control } from "react-hook-form";
 import { FormData } from "@/hooks/useEventForm";
 import { useState } from "react";
-import { categoryOptions, filterOptions, subcategoriesMap } from "@/lib/content/contentText";
-import { CATEGORY_COLORS } from "@/components/preview/constants";
+import { categoryOptions, filterOptions, subcategoriesMap, CATEGORY_COLORS } from "@/lib/content/contentText";
 
 interface StepDetailsProps {
   register: UseFormRegister<FormData>;
@@ -78,7 +77,7 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
           Select Categories <span className="text-red-500">*</span>
         </Label>
         <p className="text-xs text-muted-foreground mb-3">
-          Max {MAX_CATEGORIES} kategorier — klicka på en vald kategori för att öppna underkategorier
+          Max {MAX_CATEGORIES} categories — click a selected category to open subcategories
         </p>
         <Controller
           name="categories"
@@ -122,6 +121,7 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
                                   }
                                 };
 
+                                const color = CATEGORY_COLORS[code] ?? "#888888";
                                 return (
                                   <button
                                     key={code}
@@ -129,9 +129,9 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
                                     onClick={handleClick}
                                     disabled={!isSelected && atLimit}
                                     style={{
-                                      backgroundColor: CATEGORY_COLORS[code],
+                                      backgroundColor: color,
                                       boxShadow: isSelected
-                                        ? `0 0 0 3px white, 0 0 0 6px ${CATEGORY_COLORS[code]}`
+                                        ? `0 0 0 3px white, 0 0 0 6px ${color}`
                                         : "none",
                                       opacity: !isSelected && atLimit ? 0.35 : 1,
                                     }}
@@ -160,7 +160,7 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
                                     ({ code: subCode, label: subLabel }) => {
                                       const selected =
                                         subField.value?.[openDropdown]?.includes(subCode) ?? false;
-                                      const catColor = CATEGORY_COLORS[openDropdown];
+                                      const catColor = CATEGORY_COLORS[openDropdown] ?? "#888888";
                                       return (
                                         <button
                                           key={subCode}
@@ -219,7 +219,7 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
                     )}
                     {atLimit && (
                       <p className="text-xs text-amber-600 font-medium">
-                        Max {MAX_CATEGORIES} kategorier valda — avmarkera en för att välja en annan
+                        Max {MAX_CATEGORIES} categories selected — deselect one to choose another
                       </p>
                     )}
                   </div>

--- a/src/components/preview/constants.ts
+++ b/src/components/preview/constants.ts
@@ -136,17 +136,8 @@ export const BRAND = {
   neutral900: Neutral[900],
 } as const;
 
-// ── Category dark colors (matches CategoryDark in theme.ts) ─────────
-export const CATEGORY_COLORS: Record<number, string> = {
-  1: "#FF0000", // Events — Red
-  2: "#7030A0", // Sports — Purple
-  3: "#000000", // Entertainment — Black
-  4: "#3333CC", // Culture — Blue
-  5: "#7F7F7F", // Adventure — Gray
-  6: "#ED7D31", // Learn — Orange
-  7: "#FF3399", // Health — Pink
-  8: "#00B050", // Fun for Kids — Green
-};
+// ── Category dark colors — source of truth moved to contentText.tsx ──
+export { CATEGORY_COLORS } from "@/lib/content/contentText";
 
 // ── Category tints (matches CategoryTints in theme.ts) ──────────────
 export const CATEGORY_TINTS: Record<number, string> = {

--- a/src/lib/content/contentText.tsx
+++ b/src/lib/content/contentText.tsx
@@ -86,3 +86,15 @@ export const filterOptions: { code: number; label: string; icon: JSX.Element }[]
   { code: 1005, label: "Seniorer", icon: <Glasses className="w-6 h-6 mb-2" /> },
   { code: 1006, label: "Rullstolsanpassat", icon: <Accessibility className="w-6 h-6 mb-2" /> },
 ];
+
+// Category tile colors — one per category code, mirrors CategoryDark in mobile theme.ts
+export const CATEGORY_COLORS: Record<number, string> = {
+  1: "#FF0000", // Events — Red
+  2: "#7030A0", // Sports — Purple
+  3: "#000000", // Entertainment — Black
+  4: "#3333CC", // Culture — Blue
+  5: "#7F7F7F", // Adventure — Gray
+  6: "#ED7D31", // Learn — Orange
+  7: "#FF3399", // Health — Pink
+  8: "#00B050", // Fun for Kids — Green
+};

--- a/src/lib/content/contentText.tsx
+++ b/src/lib/content/contentText.tsx
@@ -1,16 +1,11 @@
 import {
   CalendarDays,
   Users,
-  Sparkles,
   Dribbble,
   Mountain,
   Film,
-  Music,
-  Theater,
-  Paintbrush2,
-  TreeDeciduous,
+  Landmark,
   BookOpen,
-  GraduationCap,
   HeartPulse,
   Smile,
   Home,
@@ -18,18 +13,6 @@ import {
   Glasses,
   Ticket,
   TreePine,
-  Landmark,
-  Eye,
-  Map,
-  UtensilsCrossed,
-  Compass,
-  MessageCircle,
-  UsersRound,
-  Waves,
-  HandHeart,
-  Church,
-  Baby,
-  PersonStanding,
 } from "lucide-react";
 import { JSX } from "react";
 
@@ -39,49 +22,46 @@ import { JSX } from "react";
 // Display order: family-friendly first, then broad → niche
 // ────────────────────────────────────────────────────────────────
 
-export const subcategoriesMap: Record<
-  number,
-  { code: number; label: string; icon: React.ElementType }[]
-> = {
+export const subcategoriesMap: Record<number, { code: number; label: string }[]> = {
   8: [
-    { code: 801, label: "0–4 år", icon: Baby },
-    { code: 802, label: "5–10 år", icon: Smile },
-    { code: 803, label: "11–15 år", icon: PersonStanding },
+    { code: 801, label: "0–4 år" },
+    { code: 802, label: "5–10 år" },
+    { code: 803, label: "11–15 år" },
   ],
   1: [
-    { code: 101, label: "Festivaler & nöjen", icon: Sparkles },
-    { code: 102, label: "Fritid & livsstil", icon: Users },
-    { code: 103, label: "Mässor & marknader", icon: CalendarDays },
+    { code: 101, label: "Festival & nöjen" },
+    { code: 102, label: "Fritid & livsstil" },
+    { code: 103, label: "Loppis, marknad & mässa" },
   ],
   3: [
-    { code: 301, label: "Bio & film", icon: Film },
-    { code: 302, label: "Musik & konserter", icon: Music },
-    { code: 303, label: "Teater & shower", icon: Theater },
+    { code: 301, label: "Bio & film" },
+    { code: 302, label: "Musik & konsert" },
+    { code: 303, label: "Teater & föreställning" },
   ],
   2: [
-    { code: 201, label: "Sport att utöva", icon: Dribbble },
-    { code: 202, label: "Sport att titta på", icon: Eye },
-    { code: 203, label: "Sport att prova", icon: Mountain },
+    { code: 201, label: "Idrott att utöva" },
+    { code: 202, label: "Sport att se på" },
+    { code: 203, label: "Prova på" },
   ],
   5: [
-    { code: 501, label: "Parker & leder", icon: TreeDeciduous },
-    { code: 502, label: "Mat & dryck", icon: UtensilsCrossed },
-    { code: 503, label: "Utflykter & äventyr", icon: Compass },
+    { code: 501, label: "Natur & vandring" },
+    { code: 502, label: "Mat- och dryckupplevelser" },
+    { code: 503, label: "Utflykt & äventyr" },
   ],
   4: [
-    { code: 401, label: "Guidade turer", icon: Map },
-    { code: 402, label: "Konst & gallerier", icon: Paintbrush2 },
-    { code: 403, label: "Museer & sevärdheter", icon: Landmark },
+    { code: 401, label: "Guidade turer" },
+    { code: 402, label: "Konst & gallerier" },
+    { code: 403, label: "Museum & sevärdheter" },
   ],
   6: [
-    { code: 601, label: "Föreläsningar", icon: MessageCircle },
-    { code: 602, label: "Lär dig...", icon: GraduationCap },
-    { code: 603, label: "Samlingar & möten", icon: UsersRound },
+    { code: 601, label: "Föreläsningar & samtal" },
+    { code: 602, label: "Lär dig att…" },
+    { code: 603, label: "Cirklar & mänskliga möten" },
   ],
   7: [
-    { code: 701, label: "Spa & bad", icon: Waves },
-    { code: 702, label: "Stöd & samverkan", icon: HandHeart },
-    { code: 703, label: "Trosaktiviteter", icon: Church },
+    { code: 701, label: "Spa & badhus" },
+    { code: 702, label: "Stöd & samtal" },
+    { code: 703, label: "Tro" },
   ],
 };
 


### PR DESCRIPTION
## Summary
- Per-category brand colours on all category tiles, always visible (matching mobile app)
- Outer-ring box-shadow as selection indicator — no border, no inset overlay
- Subcategory pills adopt their parent category colour with the same ring on select
- Fixed deselect UX bug: first click selects + opens panel, second click on an open tile deselects
- Enforces max 3 categories with dimmed/disabled tiles and an amber warning
- Fixed Select All / Deselect All triggering form submission (missing `type="button"`)
- Synced 17 subcategory labels with mobile app `sv.json`
- Replaced icon+square subcategory buttons with icon-free pill shape

## Changes
Resolves all tasks in issue #66:
- ✅ Update category colour codes to match the mobile app
- ✅ Update sub-categories to match the mobile app
- ✅ Remove icons from sub-category buttons
- ✅ Add help text for category selection (max 3 categories)
- ✅ Fix category visual bug (selecting on return no longer deselects)

## Test Plan
- [x] Lint passes
- [x] Type check passes
- [x] Build passes (all pages)
- [ ] Open `/create-event`, verify each category tile shows its colour
- [ ] Select a category, navigate to next step, return — tile stays selected, click opens panel
- [ ] Select 3 categories — remaining tiles dim and become unclickable
- [ ] Click Select All in subcategory panel — verify no form submission occurs
- [ ] Verify subcategory labels match the mobile app

## Cross-Repo Impact
None — display-layer only. Category and subcategory **codes** are unchanged; only labels and UI rendering were updated.

Closes #66

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>