### PR TITLE
feat: email verification page and unverified account banner (#60)

### DIFF
--- a/src/app/admin/moderation/page.tsx
+++ b/src/app/admin/moderation/page.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/dialog";
 import { useAdminReports, useDismissReports } from "@/hooks/useReports";
 import { useDeleteEvent } from "@/hooks/useEvents";
+import { getStoredJwtPayload, getRolesFromPayload } from "@/lib/jwt";
 import {
   ReportedEventSummaryDto,
   ReportReason,
@@ -156,19 +157,8 @@ export default function ModerationPage() {
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
 
   useEffect(() => {
-    const token = localStorage.getItem("accessToken");
-    if (!token) { setIsAdmin(false); return; }
-    try {
-      const payload = JSON.parse(atob(token.split(".")[1]));
-      const roles =
-        payload.role ||
-        payload["http://schemas.microsoft.com/ws/2008/06/identity/claims/role"] ||
-        [];
-      const roleArray = Array.isArray(roles) ? roles : [roles];
-      setIsAdmin(roleArray.includes("Admin"));
-    } catch {
-      setIsAdmin(false);
-    }
+    const payload = getStoredJwtPayload();
+    setIsAdmin(payload ? getRolesFromPayload(payload).includes("Admin") : false);
   }, []);
 
   const [removeTarget, setRemoveTarget] = useState<{ id: string; title: string } | null>(null);

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -6,23 +6,14 @@ import { Footer } from "@/components/global/Footer";
 import { Button } from "@/components/ui/button";
 import { CalendarPlus, Zap, List, Smartphone, Shield } from "lucide-react";
 import Link from "next/link";
+import { getStoredJwtPayload, getRolesFromPayload } from "@/lib/jwt";
 
 function getInitialAuthState() {
-  if (typeof window === "undefined") return { isLoggedIn: false, isAdmin: false };
-  const token = localStorage.getItem("accessToken");
-  if (!token) return { isLoggedIn: false, isAdmin: false };
+  const payload = getStoredJwtPayload();
+  if (!payload) return { isLoggedIn: false, isAdmin: false };
 
-  try {
-    const payload = JSON.parse(atob(token.split(".")[1]));
-    const roles =
-      payload.role ||
-      payload["http://schemas.microsoft.com/ws/2008/06/identity/claims/role"] ||
-      [];
-    const roleArray = Array.isArray(roles) ? roles : [roles];
-    return { isLoggedIn: true, isAdmin: roleArray.includes("Admin") };
-  } catch {
-    return { isLoggedIn: false, isAdmin: false };
-  }
+  const roles = getRolesFromPayload(payload);
+  return { isLoggedIn: true, isAdmin: roles.includes("Admin") };
 }
 
 export default function Home() {

--- a/src/app/my-events/page.tsx
+++ b/src/app/my-events/page.tsx
@@ -29,23 +29,11 @@ import {
 
 import { useEvents, useDeleteEvent } from "@/hooks/useEvents";
 import type { EventDto } from "@/types/events";
+import { getStoredJwtPayload, getUserIdFromPayload } from "@/lib/jwt";
 
 function getUserIdFromToken(): string | null {
-  if (typeof window === "undefined") return null;
-  const token = localStorage.getItem("accessToken");
-  if (!token) return null;
-
-  try {
-    const payload = JSON.parse(atob(token.split(".")[1]));
-    return (
-      payload.sub ||
-      payload["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"] ||
-      payload.nameid ||
-      null
-    );
-  } catch {
-    return null;
-  }
+  const payload = getStoredJwtPayload();
+  return payload ? getUserIdFromPayload(payload) : null;
 }
 
 export default function MyEventsPage() {

--- a/src/app/quick-create/page.tsx
+++ b/src/app/quick-create/page.tsx
@@ -20,6 +20,7 @@ import { Navbar } from "@/components/global/Navbar";
 import { QuickCreateForm } from "@/components/forms/QuickCreateForm";
 import { useQuickCreateEvent } from "@/hooks/useQuickCreateEvent";
 import { Button } from "@/components/ui/button";
+import { getStoredJwtPayload, getRolesFromPayload } from "@/lib/jwt";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   quickCreateSchema,
@@ -35,19 +36,8 @@ export default function QuickCreatePage() {
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
 
   useEffect(() => {
-    const token = localStorage.getItem("accessToken");
-    if (!token) { setIsAdmin(false); return; }
-    try {
-      const payload = JSON.parse(atob(token.split(".")[1]));
-      const roles =
-        payload.role ||
-        payload["http://schemas.microsoft.com/ws/2008/06/identity/claims/role"] ||
-        [];
-      const roleArray = Array.isArray(roles) ? roles : [roles];
-      setIsAdmin(roleArray.includes("Admin"));
-    } catch {
-      setIsAdmin(false);
-    }
+    const payload = getStoredJwtPayload();
+    setIsAdmin(payload ? getRolesFromPayload(payload).includes("Admin") : false);
   }, []);
 
   const form = useForm<QuickCreateFormData>({

--- a/src/components/global/Navbar.tsx
+++ b/src/components/global/Navbar.tsx
@@ -8,6 +8,7 @@ import Image from "next/image";
 
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/axios";
+import { UnverifiedEmailBanner } from "@/components/global/UnverifiedEmailBanner";
 
 export function Navbar() {
   const [showSearch, setShowSearch] = useState(false);
@@ -33,46 +34,49 @@ export function Navbar() {
   };
 
   return (
-    <header className="w-full border-b bg-white p-4">
-      <div className="max-w-7xl mx-auto flex items-center justify-between">
-        {/* Left: Logo + Text */}
-        <div className="flex items-center gap-3">
-          <Image src="/images/godologo.png" alt="Logo" width={100} height={100} />
-          <div>
-            <h1 className="text-xl font-semibold border-b-2 border-black inline-block">Go.Do.</h1>
-            <p className="text-sm italic text-gray-600">
-              More to do. <span className="text-gray-500">Close to you.</span>
-            </p>
+    <>
+      <header className="w-full border-b bg-white p-4">
+        <div className="max-w-7xl mx-auto flex items-center justify-between">
+          {/* Left: Logo + Text */}
+          <div className="flex items-center gap-3">
+            <Image src="/images/godologo.png" alt="Logo" width={100} height={100} />
+            <div>
+              <h1 className="text-xl font-semibold border-b-2 border-black inline-block">Go.Do.</h1>
+              <p className="text-sm italic text-gray-600">
+                More to do. <span className="text-gray-500">Close to you.</span>
+              </p>
+            </div>
+          </div>
+
+          {/* Right: Search */}
+          <div className="flex items-center gap-2">
+            {showSearch ? (
+              <div className="flex items-center gap-2 border rounded-md px-2 py-1 bg-white shadow-sm">
+                <Input
+                  placeholder="Search..."
+                  className="w-48 border-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                  onBlur={() => setShowSearch(false)}
+                  autoFocus
+                />
+                <Search className="w-4 h-4 text-gray-500" />
+              </div>
+            ) : (
+              <Search
+                className="w-5 h-5 text-gray-500 cursor-pointer"
+                onClick={() => setShowSearch(true)}
+              />
+            )}
+
+            {/* logout button — only when logged in */}
+            {isLoggedIn && (
+              <Button variant="outline" size="sm" onClick={onLogout}>
+                Log out
+              </Button>
+            )}
           </div>
         </div>
-
-        {/* Right: Search */}
-        <div className="flex items-center gap-2">
-          {showSearch ? (
-            <div className="flex items-center gap-2 border rounded-md px-2 py-1 bg-white shadow-sm">
-              <Input
-                placeholder="Search..."
-                className="w-48 border-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                onBlur={() => setShowSearch(false)}
-                autoFocus
-              />
-              <Search className="w-4 h-4 text-gray-500" />
-            </div>
-          ) : (
-            <Search
-              className="w-5 h-5 text-gray-500 cursor-pointer"
-              onClick={() => setShowSearch(true)}
-            />
-          )}
-
-          {/* logout button — only when logged in */}
-          {isLoggedIn && (
-            <Button variant="outline" size="sm" onClick={onLogout}>
-              Log out
-            </Button>
-          )}
-        </div>
-      </div>
-    </header>
+      </header>
+      <UnverifiedEmailBanner />
+    </>
   );
 }

--- a/src/components/global/UnverifiedEmailBanner.tsx
+++ b/src/components/global/UnverifiedEmailBanner.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/axios";
+import { getStoredJwtPayload, getEmailFromPayload } from "@/lib/jwt";
+import { Button } from "@/components/ui/button";
+import { MailWarning } from "lucide-react";
+
+function getVerificationState(): { show: boolean; email: string | null } {
+  const payload = getStoredJwtPayload();
+  if (!payload) return { show: false, email: null };
+
+  const isVerified = payload.emailVerified !== "false";
+  if (isVerified) return { show: false, email: null };
+
+  return { show: true, email: getEmailFromPayload(payload) };
+}
+
+export function UnverifiedEmailBanner() {
+  const [state, setState] = useState<{ show: boolean; email: string | null }>({
+    show: false,
+    email: null,
+  });
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  useEffect(() => {
+    setState(getVerificationState());
+  }, []);
+
+  if (!state.show) return null;
+
+  const handleResend = async () => {
+    if (!state.email || sent) return;
+    setLoading(true);
+    try {
+      const res = await api.post("/auth/resend-verification", { email: state.email });
+      const payload = res.data;
+      if (payload?.isSuccess === false) {
+        throw new Error(payload?.errors?.join(", ") || "Could not send verification email");
+      }
+      toast.success("Verification email sent. Check your inbox.");
+      setSent(true);
+    } catch {
+      toast.error("Could not send verification email. Try again later.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      role="alert"
+      className="w-full bg-yellow-100 border-b border-yellow-300 text-yellow-900 text-sm px-4 py-2.5 flex items-center justify-center gap-2 font-medium"
+    >
+      <MailWarning className="w-4 h-4 shrink-0" />
+      <span>Your email address is not verified.</span>
+      {sent ? (
+        <span className="text-yellow-800">Check your inbox for the verification link.</span>
+      ) : (
+        <Button
+          variant="link"
+          size="sm"
+          className="h-auto p-0 text-yellow-900 underline font-semibold text-sm hover:text-yellow-700"
+          onClick={handleResend}
+          disabled={loading}
+        >
+          {loading ? "Sending…" : "Resend verification email"}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,0 +1,47 @@
+type JwtPayload = Record<string, unknown>;
+
+export function parseJwtPayload(token: string): JwtPayload | null {
+  try {
+    return JSON.parse(atob(token.split(".")[1])) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function getStoredJwtPayload(): JwtPayload | null {
+  if (typeof window === "undefined") return null;
+  const token = localStorage.getItem("accessToken");
+  if (!token) return null;
+  return parseJwtPayload(token);
+}
+
+export function getRolesFromPayload(payload: JwtPayload): string[] {
+  const roles =
+    (payload.role as string | string[] | undefined) ||
+    (payload[
+      "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+    ] as string | string[] | undefined) ||
+    [];
+  return Array.isArray(roles) ? roles : [roles];
+}
+
+export function getUserIdFromPayload(payload: JwtPayload): string | null {
+  return (
+    (payload.sub as string | undefined) ||
+    (payload[
+      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
+    ] as string | undefined) ||
+    (payload.nameid as string | undefined) ||
+    null
+  );
+}
+
+export function getEmailFromPayload(payload: JwtPayload): string | null {
+  return (
+    (payload.email as string | undefined) ||
+    (payload[
+      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+    ] as string | undefined) ||
+    null
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `UnverifiedEmailBanner` component that reads the `emailVerified` JWT claim and shows a resend prompt when false — automatically appears on all pages using `<Navbar />`
- Email verification page (`/users/verify-email`) was already on this branch — handles token auto-verify, success/failed/missing-token states, and resend form
- Extracts `src/lib/jwt.ts` shared utility (`parseJwtPayload`, `getStoredJwtPayload`, `getRolesFromPayload`, `getUserIdFromPayload`, `getEmailFromPayload`) to eliminate duplicated JWT parsing across 5 files

## Notes
- Banner activates once the backend PR (email verification for organisers) is merged and starts issuing `emailVerified: "false"` in the JWT
- `handleResend` correctly checks `OperationResult.isSuccess` before showing success toast (matches pattern in `verify-email/page.tsx`)

## Test plan
- [ ] Register a new organiser account — no banner visible (backend currently hardcodes `emailVerified: true`)
- [ ] Once backend PR is merged: register, confirm banner appears on `/landing`, `/create-event`, `/my-events`
- [ ] Click "Resend verification email" — success toast shown, button replaced with inbox message
- [ ] Click verification link in email — `/users/verify-email?token=...` — success state shown
- [ ] Navigate to `/users/verify-email` without token — missing-token state shown
- [ ] Navigate to `/users/verify-email` with expired token — failed state and resend form shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
