### PR TITLE
67 event form filterstags rework

### DIFF
--- a/src/components/forms/QuickCreateForm.tsx
+++ b/src/components/forms/QuickCreateForm.tsx
@@ -232,21 +232,20 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
 
           <div className="space-y-4">
             <Label>Select Filters (optional)</Label>
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+            <div className="flex flex-wrap gap-2">
               {filterOptions.map((filter) => (
                 <Button
                   key={filter.code}
                   type="button"
                   variant={selectedFilters.includes(filter.code) ? "default" : "outline"}
                   onClick={() => handleFilterToggle(filter.code)}
-                  className={`h-auto py-3 flex flex-col items-center gap-1 ${
+                  className={`rounded-full px-4 py-2 text-sm font-medium h-auto ${
                     selectedFilters.includes(filter.code)
-                      ? "bg-black text-white"
+                      ? "bg-black text-white border-black"
                       : "border-black/20 hover:bg-gray-100"
                   }`}
                 >
-                  {filter.icon}
-                  <span className="text-xs">{filter.label}</span>
+                  {filter.label}
                 </Button>
               ))}
             </div>

--- a/src/components/forms/steps/StepEventDetails.tsx
+++ b/src/components/forms/steps/StepEventDetails.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Controller, FieldErrors, UseFormRegister, Control } from "react-hook-form";
 import { FormData } from "@/hooks/useEventForm";
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
 import { categoryOptions, filterOptions, subcategoriesMap, CATEGORY_COLORS } from "@/lib/content/contentText";
 
 interface StepDetailsProps {
@@ -102,49 +102,59 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
                             <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                               {row.map(({ code, label, icon: Icon }) => {
                                 const isSelected = (catField.value ?? []).includes(code);
+                                const color = CATEGORY_COLORS[code] ?? "#888888";
 
                                 const handleClick = () => {
                                   if (isSelected) {
-                                    if (openDropdown === code) {
-                                      // Second click on open tile → deselect + close
-                                      catField.onChange(
-                                        (catField.value ?? []).filter((c) => c !== code)
-                                      );
-                                      setOpenDropdown(null);
-                                    } else {
-                                      // First click on selected tile → open dropdown
-                                      setOpenDropdown(code);
-                                    }
+                                    // Toggle dropdown only — never deselect on tile click
+                                    setOpenDropdown(openDropdown === code ? null : code);
                                   } else if (!atLimit) {
                                     catField.onChange([...(catField.value ?? []), code]);
                                     setOpenDropdown(code);
                                   }
                                 };
 
-                                const color = CATEGORY_COLORS[code] ?? "#888888";
+                                const handleDeselect = (e: MouseEvent<HTMLButtonElement>) => {
+                                  e.stopPropagation();
+                                  catField.onChange(
+                                    (catField.value ?? []).filter((c) => c !== code)
+                                  );
+                                  if (openDropdown === code) setOpenDropdown(null);
+                                };
+
                                 return (
-                                  <button
-                                    key={code}
-                                    type="button"
-                                    onClick={handleClick}
-                                    disabled={!isSelected && atLimit}
-                                    style={{
-                                      backgroundColor: color,
-                                      boxShadow: isSelected
-                                        ? `0 0 0 3px white, 0 0 0 6px ${color}`
-                                        : "none",
-                                      opacity: !isSelected && atLimit ? 0.35 : 1,
-                                    }}
-                                    className={cn(
-                                      "flex flex-col items-center justify-center p-4 rounded-xl w-full h-24 border-0 transition-all text-white",
-                                      !isSelected && atLimit ? "cursor-not-allowed" : ""
+                                  <div key={code} className="relative w-full">
+                                    <button
+                                      type="button"
+                                      onClick={handleClick}
+                                      disabled={!isSelected && atLimit}
+                                      style={{
+                                        backgroundColor: color,
+                                        boxShadow: isSelected
+                                          ? `0 0 0 3px white, 0 0 0 6px ${color}`
+                                          : "none",
+                                        opacity: !isSelected && atLimit ? 0.35 : 1,
+                                      }}
+                                      className={cn(
+                                        "flex flex-col items-center justify-center p-4 rounded-xl w-full h-24 border-0 transition-all text-white",
+                                        !isSelected && atLimit ? "cursor-not-allowed" : ""
+                                      )}
+                                    >
+                                      <Icon className="w-6 h-6 mb-2" />
+                                      <span className="text-xs font-medium text-center">
+                                        {label}
+                                      </span>
+                                    </button>
+                                    {isSelected && (
+                                      <button
+                                        type="button"
+                                        onClick={handleDeselect}
+                                        className="absolute top-1 right-1 w-5 h-5 bg-white/30 rounded-full flex items-center justify-center text-white text-xs leading-none hover:bg-white/50 transition-colors"
+                                      >
+                                        ✕
+                                      </button>
                                     )}
-                                  >
-                                    <Icon className="w-6 h-6 mb-2" />
-                                    <span className="text-xs font-medium text-center">
-                                      {label}
-                                    </span>
-                                  </button>
+                                  </div>
                                 );
                               })}
                             </div>
@@ -197,13 +207,14 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
                                     variant="outline"
                                     size="lg"
                                     className="text-sm font-semibold px-6 py-2 border-yellow-500 text-yellow-700 hover:bg-yellow-100"
-                                    onClick={() =>
+                                    onClick={() => {
                                       toggleAllSubs(
                                         subField.value,
                                         subField.onChange,
                                         openDropdown
-                                      )
-                                    }
+                                      );
+                                      setOpenDropdown(null);
+                                    }}
                                   >
                                     {subField.value?.[openDropdown]?.length ===
                                     subcategoriesMap[openDropdown]?.length
@@ -216,11 +227,6 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
                           </div>
                         );
                       }
-                    )}
-                    {atLimit && (
-                      <p className="text-xs text-amber-600 font-medium">
-                        Max {MAX_CATEGORIES} categories selected — deselect one to choose another
-                      </p>
                     )}
                   </div>
                 );

--- a/src/components/forms/steps/StepEventDetails.tsx
+++ b/src/components/forms/steps/StepEventDetails.tsx
@@ -237,8 +237,8 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
           name="filters"
           control={control}
           render={({ field }) => (
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-              {filterOptions.map(({ code, label, icon }) => {
+            <div className="flex flex-wrap gap-2">
+              {filterOptions.map(({ code, label }) => {
                 const isSelected = (field.value ?? []).includes(code);
 
                 const toggle = () => {
@@ -254,14 +254,13 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
                     type="button"
                     onClick={toggle}
                     className={cn(
-                      "flex flex-col items-center justify-center p-4 rounded-xl w-full h-24 border transition-all text-sm font-medium",
+                      "px-4 py-2 rounded-full border text-sm font-medium transition-all",
                       isSelected
-                        ? "bg-yellow-400 text-black border-yellow-600"
+                        ? "bg-[#F3C10E] text-black border-[#F3C10E]"
                         : "bg-white text-gray-700 border-gray-300 hover:bg-gray-100"
                     )}
                   >
-                    {icon}
-                    <span className="text-center text-xs">{label}</span>
+                    {label}
                   </button>
                 );
               })}

--- a/src/lib/content/contentText.tsx
+++ b/src/lib/content/contentText.tsx
@@ -1,6 +1,5 @@
 import {
   CalendarDays,
-  Users,
   Dribbble,
   Mountain,
   Film,
@@ -8,13 +7,7 @@ import {
   BookOpen,
   HeartPulse,
   Smile,
-  Home,
-  Accessibility,
-  Glasses,
-  Ticket,
-  TreePine,
 } from "lucide-react";
-import { JSX } from "react";
 
 // ────────────────────────────────────────────────────────────────
 // 8 Categories / 24 Subcategories — aligned with backend DataSeeder
@@ -77,14 +70,12 @@ export const categoryOptions: { code: number; label: string; icon: React.Element
   { code: 7, label: "Hälsa & välmående", icon: HeartPulse },
 ];
 
-// Filter tags (1001–1006) — matches backend Tag codebook
-export const filterOptions: { code: number; label: string; icon: JSX.Element }[] = [
-  { code: 1001, label: "Gratis", icon: <Ticket className="w-6 h-6 mb-2" /> },
-  { code: 1002, label: "Familjevänligt", icon: <Users className="w-6 h-6 mb-2" /> },
-  { code: 1003, label: "Inomhus", icon: <Home className="w-6 h-6 mb-2" /> },
-  { code: 1004, label: "Utomhus", icon: <TreePine className="w-6 h-6 mb-2" /> },
-  { code: 1005, label: "Seniorer", icon: <Glasses className="w-6 h-6 mb-2" /> },
-  { code: 1006, label: "Rullstolsanpassat", icon: <Accessibility className="w-6 h-6 mb-2" /> },
+// Filter tags — aligned with mobile app (sv.json tag keys)
+export const filterOptions: { code: number; label: string }[] = [
+  { code: 1001, label: "Gratis" },
+  { code: 1003, label: "Inomhus" },
+  { code: 1004, label: "Utomhus" },
+  { code: 1005, label: "Seniorfokus" },
 ];
 
 // Category tile colors — one per category code, mirrors CategoryDark in mobile theme.ts


### PR DESCRIPTION
## Summary

Reworks the filter/tag pills and fixes category selection in the event creation form (Step 1 — Details), aligning the web form with the mobile app.

### Filter pills
- Removed wheelchair and family-friendly filters — now matches mobile app: **Gratis, Inomhus, Utomhus, Seniorfokus**
- Removed icons from all filter buttons
- Switched from fixed-size grid to `flex-wrap` pill layout — buttons size to their text content

### Category selection bug fix
Previously, clicking a selected category tile a second time (to open/close its subcategory panel) would accidentally **deselect** it — making it impossible to reliably hold 3 categories. Root cause: the dropdown-close action was coupled to deselection.

**Fix:**
- Tile click now only toggles the subcategory dropdown open/closed — never deselects
- Each selected tile gets a small **✕ button** (top-right corner) as the explicit deselect action
- Select All / Unselect All closes the subcategory panel automatically
- Removed the redundant "deselect one to choose another" warning text — grayed-out tiles already communicate the limit visually

## Test plan
- [x] Filter pills (Gratis, Inomhus, Utomhus, Seniorfokus) render without icons and wrap at narrow widths
- [x] Yellow selected / white unselected colours on filter pills
- [x] All 3 category slots can be filled without accidental deselection
- [x] ✕ button on a selected category tile deselects it and closes its panel if open
- [x] Clicking a selected tile toggles the subcategory panel open/closed without deselecting
- [x] Select All and Unselect All close the subcategory panel
- [x] Remaining tiles are grayed out once 3 categories are selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
