### PR TITLE
feat: spotlight image upload via Cloudinary (#78, #79, #80)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,9 @@
       "Bash(git checkout:*)",
       "Bash(git pull:*)",
       "Bash(gh pr create --title \"Update CLAUDE.md with recent features\" --body \"$\\(cat <<''EOF''\n## Summary\n- Update Next.js version to 16.1.4 with Turbopack\n- Add Spotlight pricing details \\(99 SEK/day + 125 SEK VAT\\)\n- Document logout functionality in Navbar\n- Add Quick Create page \\(Admin only\\)\n- Add GPS coordinates support in location step\n- Update authentication token handling docs\n\n## Test plan\n- [x] Documentation only, no code changes\n\n🤖 Generated with [Claude Code]\\(https://claude.com/claude-code\\)\nEOF\n\\)\")",
-      "Bash(where gh:*)"
+      "Bash(where gh:*)",
+      "Bash(gh issue *)",
+      "Bash(gh project *)"
     ]
   }
 }

--- a/src/components/forms/steps/StepSpotlight.tsx
+++ b/src/components/forms/steps/StepSpotlight.tsx
@@ -1,15 +1,15 @@
 // src/components/forms/steps/StepSpotlight.tsx
 import * as React from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import { Calendar as CalendarIcon } from "lucide-react";
+import { Calendar as CalendarIcon, Upload, X, ImageIcon } from "lucide-react";
 import { format, differenceInCalendarDays } from "date-fns";
-
 
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 import { cn } from "@/lib/utils";
+import { useCloudinaryUpload } from "@/hooks/useCloudinaryUpload";
 
 import type { FormData } from "@/hooks/useEventForm";
 
@@ -21,6 +21,22 @@ export function StepSpotlight() {
   const spotlight = watch("spotlight");
   const startDate = watch("spotlightStartDate");
   const endDate = watch("spotlightEndDate");
+  const spotlightImageUrl = watch("spotlightImageUrl");
+
+  const { upload, isUploading, error: uploadError, reset: resetUpload } = useCloudinaryUpload();
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleFileChange = async (file: File | null) => {
+    if (!file) return;
+    const url = await upload(file);
+    if (url) setValue("spotlightImageUrl", url, { shouldDirty: true });
+  };
+
+  const handleRemove = () => {
+    setValue("spotlightImageUrl", "", { shouldDirty: true });
+    resetUpload();
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
 
   // Ensure spotlight defaults to TRUE if undefined for any reason
   React.useEffect(() => {
@@ -29,14 +45,16 @@ export function StepSpotlight() {
     }
   }, [spotlight, setValue]);
 
-  // When spotlight is turned OFF, clear dates + errors
+  // When spotlight is turned OFF, clear dates, image + errors
   React.useEffect(() => {
     if (spotlight === false) {
       setValue("spotlightStartDate", undefined, { shouldValidate: true, shouldDirty: true });
       setValue("spotlightEndDate", undefined, { shouldValidate: true, shouldDirty: true });
+      setValue("spotlightImageUrl", "", { shouldDirty: true });
+      resetUpload();
       clearErrors(["spotlightStartDate", "spotlightEndDate"]);
     }
-  }, [spotlight, setValue, clearErrors]);
+  }, [spotlight, setValue, clearErrors, resetUpload]);
 
   const nextDay = React.useMemo(() => {
     const d = new Date();
@@ -160,6 +178,82 @@ export function StepSpotlight() {
               </div>
             )}
           />
+        </div>
+      )}
+
+      {/* Image upload */}
+      {spotlight && (
+        <div className="space-y-2">
+          <Label>Banner image (optional)</Label>
+
+          {spotlightImageUrl ? (
+            <div className="relative">
+              <div className="relative w-full aspect-video rounded-xl overflow-hidden border bg-muted">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={spotlightImageUrl}
+                  alt="Spotlight banner"
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="mt-2"
+                onClick={handleRemove}
+              >
+                <X className="mr-1 h-3 w-3" />
+                Remove / Replace
+              </Button>
+            </div>
+          ) : (
+            <div
+              className={cn(
+                "flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed p-8 text-center cursor-pointer transition-colors",
+                "hover:border-yellow-400 hover:bg-yellow-50/30",
+                isUploading && "pointer-events-none opacity-60"
+              )}
+              onClick={() => fileInputRef.current?.click()}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => {
+                e.preventDefault();
+                handleFileChange(e.dataTransfer.files[0] ?? null);
+              }}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                className="hidden"
+                onChange={(e) => handleFileChange(e.target.files?.[0] ?? null)}
+              />
+              {isUploading ? (
+                <div className="flex flex-col items-center gap-2">
+                  <div className="h-6 w-6 animate-spin rounded-full border-2 border-yellow-400 border-t-transparent" />
+                  <span className="text-sm text-muted-foreground">Uploading…</span>
+                </div>
+              ) : (
+                <>
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                    {uploadError ? (
+                      <ImageIcon className="h-5 w-5 text-destructive" />
+                    ) : (
+                      <Upload className="h-5 w-5 text-muted-foreground" />
+                    )}
+                  </div>
+                  <p className="text-sm font-medium">
+                    Drag & drop or click to upload
+                  </p>
+                  <p className="text-xs text-muted-foreground">JPEG, PNG or WebP · max 5 MB</p>
+                </>
+              )}
+            </div>
+          )}
+
+          {uploadError && (
+            <p className="text-sm text-destructive">{uploadError}</p>
+          )}
         </div>
       )}
 

--- a/src/hooks/useCloudinaryUpload.ts
+++ b/src/hooks/useCloudinaryUpload.ts
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { api } from "@/lib/axios";
 
 const MAX_SIZE = 5 * 1024 * 1024;
@@ -59,9 +59,9 @@ export function useCloudinaryUpload() {
     }
   };
 
-  const reset = () => {
+  const reset = useCallback(() => {
     setError(null);
-  };
+  }, []);
 
   return { upload, isUploading, error, reset };
 }

--- a/src/hooks/useCloudinaryUpload.ts
+++ b/src/hooks/useCloudinaryUpload.ts
@@ -1,0 +1,67 @@
+"use client";
+import { useState } from "react";
+import { api } from "@/lib/axios";
+
+const MAX_SIZE = 5 * 1024 * 1024;
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+type UploadTokenResponse = {
+  signature: string;
+  timestamp: number;
+  apiKey: string;
+  cloudName: string;
+  folder?: string;
+};
+
+export function useCloudinaryUpload() {
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const upload = async (file: File): Promise<string | null> => {
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setError("Only JPEG, PNG, or WebP images are allowed.");
+      return null;
+    }
+    if (file.size > MAX_SIZE) {
+      setError("File size must be 5 MB or less.");
+      return null;
+    }
+
+    setError(null);
+    setIsUploading(true);
+
+    try {
+      const tokenRes = await api.post<{ data: UploadTokenResponse }>("/spotlight/upload-token");
+      const { signature, timestamp, apiKey, cloudName, folder } = tokenRes.data.data;
+
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("signature", signature);
+      formData.append("timestamp", String(timestamp));
+      formData.append("api_key", apiKey);
+      if (folder) formData.append("folder", folder);
+
+      const cloudRes = await fetch(
+        `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`,
+        { method: "POST", body: formData }
+      );
+
+      if (!cloudRes.ok) throw new Error("Cloudinary upload failed.");
+
+      const cloudData = await cloudRes.json();
+      const url: string = cloudData.secure_url;
+      return url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Upload failed. Please try again.");
+      return null;
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const reset = () => {
+    setError(null);
+  };
+
+  return { upload, isUploading, error, reset };
+}

--- a/src/lib/validation/create-event-schema.ts
+++ b/src/lib/validation/create-event-schema.ts
@@ -56,6 +56,7 @@ export const createEventSchema = z.object({
   spotlight: z.boolean().optional(),
   spotlightStartDate: z.date().optional(),
   spotlightEndDate: z.date().optional(),
+  spotlightImageUrl: z.string().url().optional().or(z.literal("")),
 }).superRefine((data, ctx) => {
   if (data.hasSingleDates) {
     if (!data.startTime) {
@@ -109,6 +110,7 @@ export const defaultFormValues: CreateEventFormData = {
   spotlight: false,
   spotlightStartDate: undefined as unknown as Date,
   spotlightEndDate: undefined as unknown as Date,
+  spotlightImageUrl: "",
 };
 
 // Helper to combine date and time into ISO string
@@ -193,6 +195,7 @@ export const createPayload = (data: CreateEventFormData): CreateEventDto => {
     spotlightEndDate: data.spotlightEndDate
       ? new Date(data.spotlightEndDate).toISOString()
       : undefined,
+    spotlightImageUrl: data.spotlightImageUrl || undefined,
   };
 };
 
@@ -233,6 +236,7 @@ export const eventDtoToFormData = (event: {
   spotlight?: boolean;
   spotlightStartDate?: string;
   spotlightEndDate?: string;
+  spotlightImageUrl?: string;
 }): CreateEventFormData => {
   // Extract time from ISO date string
   const extractTime = (isoString?: string): string => {
@@ -313,5 +317,6 @@ export const eventDtoToFormData = (event: {
     spotlightEndDate: event.spotlightEndDate
       ? new Date(event.spotlightEndDate)
       : (undefined as unknown as Date),
+    spotlightImageUrl: event.spotlightImageUrl || "",
   };
 };

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -43,6 +43,7 @@ export type CreateEventDto = {
   spotlight?: boolean;
   spotlightStartDate?: string | null;
   spotlightEndDate?: string | null;
+  spotlightImageUrl?: string;
 
   // ---- Matching backend ----
   categoryCodes: number[];
@@ -96,6 +97,7 @@ export type EventDto = {
   spotlight?: boolean;
   spotlightStartDate?: string;
   spotlightEndDate?: string;
+  spotlightImageUrl?: string;
   isActive: boolean;
   createdAt: string;
   updatedAt?: string;


### PR DESCRIPTION
## Summary

- **#78** — `spotlightImageUrl` plumbing: added to `CreateEventDto`, `EventDto`, Zod schema, `defaultFormValues`, `createPayload()`, and `eventDtoToFormData()`
- **#79** — `useCloudinaryUpload` hook: client-side file validation (5 MB, JPEG/PNG/WebP) → `POST /api/spotlight/upload-token` → direct signed upload to Cloudinary → returns `secure_url`. No FE env vars needed — `cloudName` comes from the token response
- **#80** — Image upload zone in `StepSpotlight`: drag-and-drop or click-to-browse, upload spinner, 16:9 preview, remove/replace button, edit-mode pre-populate, clears automatically when spotlight is toggled off

## Notes

- Endpoint used: `POST /api/spotlight/upload-token` (updated per [BE review comment](https://github.com/Go-Do-AB/Frontend/issues/79#issuecomment-4691881786))
- Resolved merge conflict with dates rework (main had landed `hasMultipleDates`, `weekdays[]`, `superRefine` validator)

## Test plan

- [ ] Toggle spotlight on → upload zone appears
- [ ] Upload a valid image → preview renders, `spotlightImageUrl` in payload on submit
- [ ] Upload oversized or wrong-type file → inline error, no crash
- [ ] Remove image → clears preview and payload field
- [ ] Toggle spotlight off → upload zone and image URL cleared
- [ ] Edit an existing event with `spotlightImageUrl` → preview pre-populates
- [ ] `npm run lint && npx tsc --noEmit && npm run build` all pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)