### PR TITLE
feat: translate frontend to Swedish, remove streetName2 (closes #87)

### DIFF
--- a/.claude/current-work.md
+++ b/.claude/current-work.md
@@ -3,41 +3,38 @@
 > **This file is read at the start of every Claude Code session and updated on every commit/push.**
 > It provides continuity between sessions.
 
-Last updated: 2026-05-20
+Last updated: 2026-06-12
 
 ## Active Task
-**Admin Moderation Dashboard (Frontend#48 / Backend#74)** — FE implementation complete, pending BE endpoints.
+**Translate frontend to Swedish — Issue #87** — PR #89 open, issue moved to "In Review".
 
-### What was done (2026-05-20):
+### What was done (2026-06-12):
 
-**Admin Moderation Dashboard (branch `feature/admin-moderation-dashboard`):**
+**Branch: `87-translate-event-creation-form-to-swedish`** — PR #89
 
-1. **`src/types/events.ts`** — added `ReportReason` enum (8 values) + `ReportReasonLabel`
-   Swedish label map, `ReportStatus` enum, `EventReportDto`, `ReportedEventSummaryDto`.
-2. **`src/hooks/useReports.ts`** — `useAdminReports()` (GET `/api/admin/reports`) and
-   `useDismissReports()` (POST `/api/admin/reports/{eventId}/dismiss`).
-3. **`src/app/admin/moderation/page.tsx`** — admin-gated dashboard (same JWT role-check
-   pattern as quick-create). 6-column table sorted by report count: title, report count badge,
-   reason chips (Swedish, truncated), AI score badge (green/amber/red), status pill,
-   Remove + Dismiss actions. Dialog confirm before remove. Skeleton / empty / error states.
-4. **`src/app/admin/moderation/layout.tsx`** — server layout holding page metadata
-   ("Moderation | GODO Admin"). Needed because page.tsx is a client component.
-5. **`src/app/landing/page.tsx`** — added "Moderation" button for admin users beside
-   "Quick Add Place", linking to `/admin/moderation`.
+All UI strings translated to Swedish across every page and form step:
+- `create-event/page.tsx`, `my-events/page.tsx`, `my-events/[id]/edit/page.tsx`
+- `landing/page.tsx`, `profile/page.tsx`, `quick-create/page.tsx`
+- `(auth)/login`, `register`, `forgot-password`, `reset-password`
+- All 5 form steps, `EventFormStepper.tsx`, `QuickCreateForm.tsx`, `Navbar.tsx`, `TimePicker.tsx`
+- All Zod validation messages in `create-event-schema.ts`
 
-All phases complete. All gates green: tsc, lint, build (19 static pages).
+Removals and fixes:
+- `streetName2` removed from form/schema/payload/edit adapter (kept in `EventDto` for backend compat)
+- "Not all fields required" notice removed
+- `TimePicker` now stores and displays `HH:mm` (was `HH:mm:ss`, was showing AM/PM)
+- `houseNumber` default fixed from `0` to `undefined`
+- `filters` error message fixed to "Välj minst ett filter"
+- Debug `console.log` calls removed from create and edit pages
+- English strings archived in `src/lib/content/strings-en.ts`
 
 ### Decisions made
-- Used `Dialog` (available) instead of `AlertDialog` (not installed) for confirm flow.
-- Metadata placed in `layout.tsx` because `metadata` export is not allowed in `"use client"` pages.
-- No pagination — report volume expected to be low; can add later if needed.
+- `streetName2` kept in `EventDto`/`CreateEventDto` types for backend API compatibility
+- No language toggle — Swedish only as specified
 
 ### What's next:
-1. **PR to main** once this is reviewed.
-2. **Wire to real data** when Backend ships `GET /api/admin/reports` and
-   `POST /api/admin/reports/{eventId}/dismiss` (tracked in Backend#74).
-3. Confirm response shape with BE: assumed `OperationResult<ReportedEventSummaryDto[]>`.
-4. Move Frontend#48 to "In Review" on the project board after PR is opened.
+1. **PR #89 awaits review** — merge when approved.
+2. Move issue #87 to "Done" on project board after PR is merged.
 
 ## Previous Session (2026-05-19)
 Privacy Policy page (bilingual, DRAFT) — branch `feature/privacy-policy`.

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -30,14 +30,14 @@ export default function ForgotPasswordPage() {
     setLoading(true);
     try {
       await api.post("/organisers/auth/forgot-password", { email: values.email });
-      toast.success("If the email exists, a reset link is on its way.");
+      toast.success("Om e-postadressen finns skickas en återställningslänk.");
       setSubmitted(true);
     } catch (e: unknown) {
       const axiosErr = e as { response?: { data?: { message?: string; errors?: string[] } } };
       const msg =
         axiosErr?.response?.data?.message ||
         axiosErr?.response?.data?.errors?.join(", ") ||
-        (e instanceof Error ? e.message : "Something went wrong");
+        (e instanceof Error ? e.message : "Något gick fel");
       toast.error(msg);
     } finally {
       setLoading(false);
@@ -56,10 +56,10 @@ export default function ForgotPasswordPage() {
           <Card className="shadow-lg border-black/10 bg-white">
             <CardHeader className="text-center">
               <CardTitle className="text-xl sm:text-2xl font-semibold text-black">
-                Reset your password
+                Återställ ditt lösenord
               </CardTitle>
               <p className="text-sm text-black/70 mt-2">
-                Enter the email for your organiser account and we&apos;ll send a reset link.
+                Ange e-postadressen för ditt arrangörskonto så skickar vi en återställningslänk.
               </p>
             </CardHeader>
 
@@ -67,28 +67,27 @@ export default function ForgotPasswordPage() {
               {submitted ? (
                 <div className="space-y-4 text-center">
                   <p className="text-black">
-                    If an account exists for that email, a reset link has been sent. The link is
-                    valid for 15 minutes.
+                    Om ett konto finns för den e-postadressen har en återställningslänk skickats. Länken är giltig i 15 minuter.
                   </p>
                   <p className="text-sm text-black/70">
-                    Check your spam folder if it hasn&apos;t arrived.
+                    Kolla din skräppostmapp om den inte har kommit fram.
                   </p>
                 </div>
               ) : (
                 <form className="space-y-5" onSubmit={handleSubmit(onSubmit)} noValidate>
                   <div className="space-y-2">
                     <Label htmlFor="email" className="text-black">
-                      Email
+                      E-post
                     </Label>
                     <Input
                       id="email"
                       type="email"
                       autoComplete="email"
                       {...register("email", {
-                        required: "Email is required",
+                        required: "E-post krävs",
                         pattern: {
                           value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-                          message: "Enter a valid email",
+                          message: "Ange en giltig e-postadress",
                         },
                       })}
                       className="bg-white"
@@ -103,7 +102,7 @@ export default function ForgotPasswordPage() {
                     disabled={loading}
                     className="w-full bg-black text-white hover:bg-black/90 transition-all disabled:opacity-60"
                   >
-                    {loading ? "Sending…" : "Send reset link"}
+                    {loading ? "Skickar…" : "Skicka återställningslänk"}
                   </Button>
                 </form>
               )}
@@ -114,7 +113,7 @@ export default function ForgotPasswordPage() {
                 href="/login"
                 className="text-sm underline underline-offset-4 text-black"
               >
-                Back to login
+                Tillbaka till inloggning
               </Link>
             </CardFooter>
           </Card>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -45,14 +45,14 @@ export default function LoginPage() {
         localStorage.setItem("accessToken", token);
       }
 
-      toast.success("Logged in");
+      toast.success("Inloggad");
       router.replace(LANDING_PATH);
     } catch (e: unknown) {
       const axiosErr = e as { response?: { data?: { message?: string; errors?: string[] } } };
       const msg =
         axiosErr?.response?.data?.message ||
         axiosErr?.response?.data?.errors?.join(", ") ||
-        (e instanceof Error ? e.message : "Login failed");
+        (e instanceof Error ? e.message : "Inloggningen misslyckades");
       toast.error(msg);
       console.error("Login error:", msg);
     }
@@ -72,7 +72,7 @@ export default function LoginPage() {
           <Card className="shadow-lg border-black/10 bg-white">
             <CardHeader className="text-center">
               <CardTitle className="text-xl sm:text-2xl font-semibold text-black">
-                Log in as an organizer
+                Logga in som arrangör
               </CardTitle>
             </CardHeader>
 
@@ -80,11 +80,11 @@ export default function LoginPage() {
               <form className="space-y-5" onSubmit={handleSubmit(onSubmit)} noValidate>
                 <div className="space-y-2">
                   <Label htmlFor="username" className="text-black">
-                    Username
+                    Användarnamn
                   </Label>
                   <Input
                     id="username"
-                    {...register("username", { required: "Username is required" })}
+                    {...register("username", { required: "Användarnamn krävs" })}
                     className="bg-white"
                   />
                   {errors.username && (
@@ -94,12 +94,12 @@ export default function LoginPage() {
 
                 <div className="space-y-2">
                   <Label htmlFor="password" className="text-black">
-                    Password
+                    Lösenord
                   </Label>
                   <Input
                     id="password"
                     type="password"
-                    {...register("password", { required: "Password is required" })}
+                    {...register("password", { required: "Lösenord krävs" })}
                     className="bg-white"
                   />
                   {errors.password && (
@@ -111,14 +111,14 @@ export default function LoginPage() {
                   type="submit"
                   className="w-full bg-black text-white hover:bg-black/90 transition-all"
                 >
-                  Log in
+                  Logga in
                 </Button>
               </form>
             </CardContent>
 
             <CardFooter className="flex flex-col gap-3">
               <Button variant="outline" className="w-full border-black/20" asChild>
-                <Link href="/register">Register as an organizer</Link>
+                <Link href="/register">Registrera dig som arrangör</Link>
               </Button>
 
               <div className="text-center">
@@ -126,7 +126,7 @@ export default function LoginPage() {
                   href="/forgot-password"
                   className="text-sm underline underline-offset-4 text-black"
                 >
-                  Forgot my password
+                  Glömt mitt lösenord
                 </Link>
               </div>
 
@@ -135,7 +135,7 @@ export default function LoginPage() {
                   href="/preview"
                   className="flex items-center justify-center gap-2 w-full py-2.5 rounded-lg bg-brand text-black text-sm font-semibold hover:brightness-95 transition-colors"
                 >
-                  See the app in action
+                  Se appen i action
                   <span aria-hidden="true">&rarr;</span>
                 </Link>
               </div>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -90,14 +90,14 @@ export default function OrganizerRegisterPage() {
       const token = parsed?.data?.token;
       if (token) localStorage.setItem("accessToken", token);
 
-      toast.success("Organizer account created successfully!");
+      toast.success("Arrangörskontot skapades!");
       router.replace(LANDING_PATH);
     } catch (e: unknown) {
       const axiosErr = e as { response?: { data?: OperationResult<unknown> } };
       const message =
         axiosErr?.response?.data?.message ||
         axiosErr?.response?.data?.errors?.join(", ") ||
-        (e instanceof Error ? e.message : "Registration failed");
+        (e instanceof Error ? e.message : "Registreringen misslyckades");
       setError("root", { message });
       toast.error(message);
     }
@@ -116,21 +116,21 @@ export default function OrganizerRegisterPage() {
             <Card className="shadow-lg border-black/10 bg-white">
               <CardHeader className="text-center">
                 <CardTitle className="text-2xl font-semibold text-black">
-                  Register as an organizer
+                  Registrera dig som arrangör
                 </CardTitle>
               </CardHeader>
 
               <CardContent>
                 <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
                   <div>
-                    <Label htmlFor="username">Username</Label>
+                    <Label htmlFor="username">Användarnamn</Label>
                     <Input
                       id="username"
                       autoComplete="username"
                       {...register("username", {
-                        required: "Username is required",
-                        minLength: { value: 3, message: "Min 3 characters" },
-                        maxLength: { value: 64, message: "Max 64 characters" },
+                        required: "Användarnamn krävs",
+                        minLength: { value: 3, message: "Min 3 tecken" },
+                        maxLength: { value: 64, message: "Max 64 tecken" },
                       })}
                     />
                     {errors.username && (
@@ -139,14 +139,14 @@ export default function OrganizerRegisterPage() {
                   </div>
 
                   <div>
-                    <Label htmlFor="password">Password</Label>
+                    <Label htmlFor="password">Lösenord</Label>
                     <Input
                       id="password"
                       type="password"
                       autoComplete="new-password"
                       {...register("password", {
-                        required: "Password is required",
-                        minLength: { value: 6, message: "Min 6 characters" },
+                        required: "Lösenord krävs",
+                        minLength: { value: 6, message: "Min 6 tecken" },
                       })}
                     />
                     {errors.password && (
@@ -155,13 +155,13 @@ export default function OrganizerRegisterPage() {
                   </div>
 
                   <div>
-                    <Label htmlFor="fullName">Full name</Label>
+                    <Label htmlFor="fullName">Fullständigt namn</Label>
                     <Input
                       id="fullName"
                       autoComplete="name"
                       {...register("fullName", {
-                        required: "Full name is required",
-                        minLength: { value: 2, message: "Min 2 characters" },
+                        required: "Fullständigt namn krävs",
+                        minLength: { value: 2, message: "Min 2 tecken" },
                       })}
                     />
                     {errors.fullName && (
@@ -170,10 +170,10 @@ export default function OrganizerRegisterPage() {
                   </div>
 
                   <div>
-                    <Label htmlFor="businessName">Business name</Label>
+                    <Label htmlFor="businessName">Företagsnamn</Label>
                     <Input
                       id="businessName"
-                      {...register("businessName", { required: "Business name is required" })}
+                      {...register("businessName", { required: "Företagsnamn krävs" })}
                     />
                     {errors.businessName && (
                       <p className="text-red-500 text-sm mt-1">{errors.businessName.message}</p>
@@ -181,12 +181,12 @@ export default function OrganizerRegisterPage() {
                   </div>
 
                   <div>
-                    <Label htmlFor="phoneNumber">Phone number</Label>
+                    <Label htmlFor="phoneNumber">Telefonnummer</Label>
                     <Input
                       id="phoneNumber"
                       type="tel"
                       autoComplete="tel"
-                      {...register("phoneNumber", { required: "Phone number is required" })}
+                      {...register("phoneNumber", { required: "Telefonnummer krävs" })}
                     />
                     {errors.phoneNumber && (
                       <p className="text-red-500 text-sm mt-1">{errors.phoneNumber.message}</p>
@@ -194,11 +194,11 @@ export default function OrganizerRegisterPage() {
                   </div>
 
                   <div>
-                    <Label htmlFor="organisationNumber">Organisation number</Label>
+                    <Label htmlFor="organisationNumber">Organisationsnummer</Label>
                     <Input
                       id="organisationNumber"
                       {...register("organisationNumber", {
-                        required: "Organisation number is required",
+                        required: "Organisationsnummer krävs",
                       })}
                     />
                     {errors.organisationNumber && (
@@ -209,16 +209,16 @@ export default function OrganizerRegisterPage() {
                   </div>
 
                   <div>
-                    <Label htmlFor="email">Email</Label>
+                    <Label htmlFor="email">E-post</Label>
                     <Input
                       id="email"
                       type="email"
                       autoComplete="email"
                       {...register("email", {
-                        required: "Email is required",
+                        required: "E-post krävs",
                         pattern: {
                           value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-                          message: "Invalid email address",
+                          message: "Ogiltig e-postadress",
                         },
                       })}
                     />
@@ -233,18 +233,18 @@ export default function OrganizerRegisterPage() {
                       type="checkbox"
                       className="h-4 w-4"
                       {...register("acceptTerms", {
-                        validate: (v) => v === true || "You must accept the terms",
+                        validate: (v) => v === true || "Du måste godkänna villkoren",
                       })}
                     />
                     <Label htmlFor="acceptTerms" className="text-sm text-gray-700">
-                      I agree to the Terms and Conditions and have read the{" "}
+                      Jag godkänner villkoren och har läst{" "}
                       <a
                         href="/privacy"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="underline"
                       >
-                        Privacy Policy
+                        integritetspolicyn
                       </a>
                     </Label>
                   </div>
@@ -259,7 +259,7 @@ export default function OrganizerRegisterPage() {
                     className="w-full bg-black text-white hover:bg-gray-800 mt-4 disabled:opacity-50"
                     disabled={isSubmitting}
                   >
-                    {isSubmitting ? "Registering..." : "Register"}
+                    {isSubmitting ? "Registrerar..." : "Registrera"}
                   </Button>
 
                   {errors.root?.message && (
@@ -270,12 +270,12 @@ export default function OrganizerRegisterPage() {
 
               <CardFooter className="text-center">
                 <p className="text-sm text-gray-600">
-                  Already have an account{" "}
+                  Har du redan ett konto?{" "}
                   <span
                     className="text-blue-600 cursor-pointer hover:underline"
                     onClick={() => router.push("/login")}
                   >
-                    Log in
+                    Logga in
                   </span>
                 </p>
               </CardFooter>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -47,14 +47,14 @@ function ResetPasswordInner() {
         throw new Error(payload?.message ?? "Reset failed");
       }
 
-      toast.success("Password updated. You can now log in.");
+      toast.success("Lösenordet har uppdaterats. Du kan nu logga in.");
       router.replace("/login");
     } catch (e: unknown) {
       const axiosErr = e as { response?: { data?: { message?: string; errors?: string[] } } };
       const msg =
         axiosErr?.response?.data?.message ||
         axiosErr?.response?.data?.errors?.join(", ") ||
-        (e instanceof Error ? e.message : "Reset failed");
+        (e instanceof Error ? e.message : "Återställningen misslyckades");
       toast.error(msg);
     } finally {
       setLoading(false);
@@ -73,7 +73,7 @@ function ResetPasswordInner() {
           <Card className="shadow-lg border-black/10 bg-white">
             <CardHeader className="text-center">
               <CardTitle className="text-xl sm:text-2xl font-semibold text-black">
-                Choose a new password
+                Välj ett nytt lösenord
               </CardTitle>
             </CardHeader>
 
@@ -84,22 +84,22 @@ function ResetPasswordInner() {
                     Återställningslänken saknas eller är ogiltig.
                   </p>
                   <p className="text-sm text-black/70">
-                    Request a new reset link from the forgot-password page.
+                    Begär en ny återställningslänk från sidan för glömt lösenord.
                   </p>
                 </div>
               ) : (
                 <form className="space-y-5" onSubmit={handleSubmit(onSubmit)} noValidate>
                   <div className="space-y-2">
                     <Label htmlFor="password" className="text-black">
-                      New password
+                      Nytt lösenord
                     </Label>
                     <Input
                       id="password"
                       type="password"
                       autoComplete="new-password"
                       {...register("password", {
-                        required: "Password is required",
-                        minLength: { value: 8, message: "At least 8 characters" },
+                        required: "Lösenord krävs",
+                        minLength: { value: 8, message: "Minst 8 tecken" },
                       })}
                       className="bg-white"
                     />
@@ -110,15 +110,15 @@ function ResetPasswordInner() {
 
                   <div className="space-y-2">
                     <Label htmlFor="confirmPassword" className="text-black">
-                      Confirm new password
+                      Bekräfta nytt lösenord
                     </Label>
                     <Input
                       id="confirmPassword"
                       type="password"
                       autoComplete="new-password"
                       {...register("confirmPassword", {
-                        required: "Please confirm your password",
-                        validate: (v) => v === passwordValue || "Passwords do not match",
+                        required: "Bekräfta ditt lösenord",
+                        validate: (v) => v === passwordValue || "Lösenorden matchar inte",
                       })}
                       className="bg-white"
                     />
@@ -132,7 +132,7 @@ function ResetPasswordInner() {
                     disabled={loading}
                     className="w-full bg-black text-white hover:bg-black/90 transition-all disabled:opacity-60"
                   >
-                    {loading ? "Updating…" : "Update password"}
+                    {loading ? "Uppdaterar…" : "Uppdatera lösenord"}
                   </Button>
                 </form>
               )}
@@ -143,7 +143,7 @@ function ResetPasswordInner() {
                 href="/login"
                 className="text-sm underline underline-offset-4 text-black"
               >
-                Back to login
+                Tillbaka till inloggning
               </Link>
             </CardFooter>
           </Card>

--- a/src/app/create-event/page.tsx
+++ b/src/app/create-event/page.tsx
@@ -30,11 +30,11 @@ import {
 } from "@/lib/validation/create-event-schema";
 
 const steps = [
-  { label: "Details", icon: <Info className="w-4 h-4 mr-1" /> },
-  { label: "Location", icon: <MapPin className="w-4 h-4 mr-1" /> },
-  { label: "Date & Time", icon: <Clock className="w-4 h-4 mr-1" /> },
+  { label: "Detaljer", icon: <Info className="w-4 h-4 mr-1" /> },
+  { label: "Plats", icon: <MapPin className="w-4 h-4 mr-1" /> },
+  { label: "Datum & Tid", icon: <Clock className="w-4 h-4 mr-1" /> },
   { label: "Spotlight", icon: <Sparkles className="w-4 h-4 mr-1" /> },
-  { label: "Confirm", icon: <CheckCircleIcon className="w-4 h-4 mr-1" /> },
+  { label: "Bekräfta", icon: <CheckCircleIcon className="w-4 h-4 mr-1" /> },
 ];
 
 export default function CreateEventPage() {
@@ -72,7 +72,6 @@ export default function CreateEventPage() {
   const prevStep = () => setStep((s) => Math.max(s - 1, 0));
 
   const onSubmit = (data: CreateEventFormData) => {
-    console.log("running");
     try {
       const payload: CreateEventDto = createPayload(data);
 
@@ -84,8 +83,8 @@ export default function CreateEventPage() {
             <div className="flex items-start gap-3 text-black">
               <CheckCircle className="text-green-500 mt-1" />
               <div>
-                <p className="font-semibold">Event created!</p>
-                <p className="text-sm">Your event is now live on Go.Do.</p>
+                <p className="font-semibold">Evenemanget skapades!</p>
+                <p className="text-sm">Ditt evenemang är nu publicerat på Go.Do.</p>
               </div>
             </div>
           );
@@ -95,21 +94,20 @@ export default function CreateEventPage() {
             <div className="flex items-start gap-3 text-black">
               <XCircle className="text-red-500 mt-1" />
               <div>
-                <p className="font-semibold">Submission failed</p>
-                <p className="text-sm">Please check your input and try again.</p>
+                <p className="font-semibold">Kunde inte skicka in</p>
+                <p className="text-sm">Kontrollera dina uppgifter och försök igen.</p>
               </div>
             </div>
           );
         },
       });
     } catch (err) {
-      console.log(err);
       toast(
         <div className="flex items-start gap-3 text-black">
           <XCircle className="text-red-500 mt-1" />
           <div>
-            <p className="font-semibold">Unexpected error</p>
-            <p className="text-sm">Something went wrong, please try again later.</p>
+            <p className="font-semibold">Oväntat fel</p>
+            <p className="text-sm">Något gick fel, försök igen senare.</p>
           </div>
         </div>
       );
@@ -124,11 +122,11 @@ export default function CreateEventPage() {
           <Link href="/landing">
             <Button variant="ghost" size="sm" className="gap-2 hover:bg-black/10">
               <ArrowLeft className="w-4 h-4" />
-              Back to Home
+              Tillbaka till startsidan
             </Button>
           </Link>
         </div>
-        <h1 className="text-4xl font-bold mb-6">Create an Event</h1>
+        <h1 className="text-4xl font-bold mb-6">Skapa ett evenemang</h1>
 
         <div className="w-full max-w-xl mb-6">
           <div className="flex justify-between text-sm font-medium mb-2">

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -37,8 +37,8 @@ export default function Home() {
         {/* Right: Call to Action */}
         <div className="max-w-md text-right space-y-4">
           <p className="text-lg font-medium mb-4">
-            Are you organizing an event? <br />
-            Make it visible on <span className="font-bold">Go.Do.</span>
+            Arrangerar du ett evenemang? <br />
+            Gör det synligt på <span className="font-bold">Go.Do.</span>
           </p>
           <div className="flex flex-col gap-3">
             <Link href="/create-event">
@@ -46,7 +46,7 @@ export default function Home() {
                 variant="default"
                 className="w-52 h-12 cursor-pointer transition-transform hover:scale-105 hover:shadow-lg"
               >
-                Create an Event
+                Skapa ett evenemang
                 <CalendarPlus className="mr-2 h-4 w-4" />
               </Button>
             </Link>
@@ -57,7 +57,7 @@ export default function Home() {
                   className="w-52 h-10 cursor-pointer transition-transform hover:scale-105 hover:shadow-lg border-black/30 bg-white/50 hover:bg-white"
                 >
                   <Zap className="mr-2 h-4 w-4" />
-                  Quick Add Place
+                  Lägg till plats
                 </Button>
               </Link>
             )}
@@ -68,7 +68,7 @@ export default function Home() {
                   className="w-52 h-10 cursor-pointer transition-transform hover:scale-105 hover:shadow-lg border-black/30 bg-white/50 hover:bg-white"
                 >
                   <Shield className="mr-2 h-4 w-4" />
-                  Moderation
+                  Moderering
                 </Button>
               </Link>
             )}
@@ -79,7 +79,7 @@ export default function Home() {
                   className="w-52 h-10 cursor-pointer transition-transform hover:scale-105 hover:shadow-lg border-black/30 bg-white/50 hover:bg-white"
                 >
                   <List className="mr-2 h-4 w-4" />
-                  My Events
+                  Mina evenemang
                 </Button>
               </Link>
             )}
@@ -90,15 +90,15 @@ export default function Home() {
                 className="w-52 h-10 cursor-pointer transition-transform hover:scale-105 hover:shadow-lg border-black/30 bg-white/50 hover:bg-white"
               >
                 <Smartphone className="mr-2 h-4 w-4" />
-                Try the App
+                Prova appen
               </Button>
             </Link>
           {!isLoggedIn && (
             <p className="text-xs text-gray-600">
               <Link href="/login" className="underline">
-                Log in
+                Logga in
               </Link>{" "}
-              to manage your events
+              för att hantera dina evenemang
             </p>
           )}
         </div>

--- a/src/app/my-events/[id]/edit/page.tsx
+++ b/src/app/my-events/[id]/edit/page.tsx
@@ -31,11 +31,11 @@ import {
 } from "@/lib/validation/create-event-schema";
 
 const steps = [
-  { label: "Details", icon: <Info className="w-4 h-4 mr-1" /> },
-  { label: "Location", icon: <MapPin className="w-4 h-4 mr-1" /> },
-  { label: "Date & Time", icon: <Clock className="w-4 h-4 mr-1" /> },
+  { label: "Detaljer", icon: <Info className="w-4 h-4 mr-1" /> },
+  { label: "Plats", icon: <MapPin className="w-4 h-4 mr-1" /> },
+  { label: "Datum & Tid", icon: <Clock className="w-4 h-4 mr-1" /> },
   { label: "Spotlight", icon: <Sparkles className="w-4 h-4 mr-1" /> },
-  { label: "Confirm", icon: <CheckCircleIcon className="w-4 h-4 mr-1" /> },
+  { label: "Bekräfta", icon: <CheckCircleIcon className="w-4 h-4 mr-1" /> },
 ];
 
 export default function EditEventPage() {
@@ -83,8 +83,8 @@ export default function EditEventPage() {
               <div className="flex items-start gap-3 text-black">
                 <CheckCircle className="text-green-500 mt-1" />
                 <div>
-                  <p className="font-semibold">Event updated!</p>
-                  <p className="text-sm">Your changes have been saved.</p>
+                  <p className="font-semibold">Evenemanget uppdaterades!</p>
+                  <p className="text-sm">Dina ändringar har sparats.</p>
                 </div>
               </div>
             );
@@ -95,22 +95,21 @@ export default function EditEventPage() {
               <div className="flex items-start gap-3 text-black">
                 <XCircle className="text-red-500 mt-1" />
                 <div>
-                  <p className="font-semibold">Update failed</p>
-                  <p className="text-sm">Please check your input and try again.</p>
+                  <p className="font-semibold">Uppdateringen misslyckades</p>
+                  <p className="text-sm">Kontrollera dina uppgifter och försök igen.</p>
                 </div>
               </div>
             );
           },
         }
       );
-    } catch (err) {
-      console.error(err);
+    } catch {
       toast(
         <div className="flex items-start gap-3 text-black">
           <XCircle className="text-red-500 mt-1" />
           <div>
-            <p className="font-semibold">Unexpected error</p>
-            <p className="text-sm">Something went wrong, please try again later.</p>
+            <p className="font-semibold">Oväntat fel</p>
+            <p className="text-sm">Något gick fel, försök igen senare.</p>
           </div>
         </div>
       );
@@ -125,7 +124,7 @@ export default function EditEventPage() {
         <section className="flex-1 flex items-center justify-center">
           <div className="flex flex-col items-center gap-4">
             <Loader2 className="w-8 h-8 animate-spin" />
-            <p>Loading event...</p>
+            <p>Laddar evenemang...</p>
           </div>
         </section>
       </main>
@@ -140,15 +139,15 @@ export default function EditEventPage() {
         <section className="flex-1 flex items-center justify-center">
           <div className="bg-white p-6 rounded-lg shadow text-center">
             <XCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
-            <h2 className="text-xl font-bold mb-2">Event not found</h2>
+            <h2 className="text-xl font-bold mb-2">Evenemanget hittades inte</h2>
             <p className="text-gray-600 mb-4">
-              The event you&apos;re trying to edit doesn&apos;t exist.
+              Evenemanget du försöker redigera finns inte.
             </p>
             <button
               onClick={() => router.push("/my-events")}
               className="px-4 py-2 bg-black text-white rounded hover:bg-gray-800"
             >
-              Back to My Events
+              Tillbaka till mina evenemang
             </button>
           </div>
         </section>
@@ -164,11 +163,11 @@ export default function EditEventPage() {
           <Link href="/my-events">
             <Button variant="ghost" size="sm" className="gap-2 hover:bg-black/10">
               <ArrowLeft className="w-4 h-4" />
-              Back to My Events
+              Tillbaka till mina evenemang
             </Button>
           </Link>
         </div>
-        <h1 className="text-4xl font-bold mb-6">Edit Event</h1>
+        <h1 className="text-4xl font-bold mb-6">Redigera evenemang</h1>
 
         <div className="w-full max-w-xl mb-6">
           <div className="flex justify-between text-sm font-medium mb-2">
@@ -203,7 +202,7 @@ export default function EditEventPage() {
           <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
             <div className="bg-white p-6 rounded-lg flex items-center gap-3">
               <Loader2 className="w-6 h-6 animate-spin" />
-              <span>Saving changes...</span>
+              <span>Sparar ändringar...</span>
             </div>
           </div>
         )}

--- a/src/app/my-events/page.tsx
+++ b/src/app/my-events/page.tsx
@@ -74,12 +74,12 @@ export default function MyEventsPage() {
 
     deleteEvent(deletingEvent.id, {
       onSuccess: () => {
-        toast.success("Event deleted successfully");
+        toast.success("Evenemanget togs bort");
         setDeletingEvent(null);
         refetch();
       },
       onError: () => {
-        toast.error("Failed to delete event");
+        toast.error("Det gick inte att ta bort evenemanget");
       },
     });
   };
@@ -118,10 +118,10 @@ export default function MyEventsPage() {
 
       <section className="flex-1 px-6 py-10 max-w-6xl mx-auto w-full">
         <div className="flex justify-between items-center mb-8">
-          <h1 className="text-4xl font-bold">My Events</h1>
+          <h1 className="text-4xl font-bold">Mina evenemang</h1>
           <Button onClick={() => router.push("/create-event")} className="gap-2">
             <Plus className="w-4 h-4" />
-            Create New Event
+            Skapa nytt evenemang
           </Button>
         </div>
 
@@ -134,7 +134,7 @@ export default function MyEventsPage() {
         {error && (
           <Card className="bg-red-50 border-red-200">
             <CardContent className="py-6 text-center text-red-700">
-              Failed to load events. Please try again.
+              Det gick inte att hämta evenemang. Försök igen.
             </CardContent>
           </Card>
         )}
@@ -142,8 +142,8 @@ export default function MyEventsPage() {
         {!isLoading && events.length === 0 && (
           <Card className="bg-white">
             <CardContent className="py-12 text-center">
-              <p className="text-lg text-gray-600 mb-4">No events yet</p>
-              <Button onClick={() => router.push("/create-event")}>Create your first event</Button>
+              <p className="text-lg text-gray-600 mb-4">Inga evenemang än</p>
+              <Button onClick={() => router.push("/create-event")}>Skapa ditt första evenemang</Button>
             </CardContent>
           </Card>
         )}
@@ -189,14 +189,14 @@ export default function MyEventsPage() {
                         <Calendar className="w-4 h-4 mt-0.5 text-gray-500" />
                         <div>
                           {event.isAlwaysOpen ? (
-                            <p>Always open</p>
+                            <p>Alltid öppet</p>
                           ) : event.hasSingleDates ? (
                             <>
                               <p>Start: {formatDate(event.startDate)}</p>
-                              <p>End: {formatDate(event.endDate)}</p>
+                              <p>Slut: {formatDate(event.endDate)}</p>
                             </>
                           ) : (
-                            <p>Recurring event</p>
+                            <p>Återkommande evenemang</p>
                           )}
                         </div>
                       </div>
@@ -243,7 +243,7 @@ export default function MyEventsPage() {
                   <ChevronLeft className="w-4 h-4" />
                 </Button>
                 <span className="text-sm">
-                  Page {pageNumber} of {totalPages}
+                  Sida {pageNumber} av {totalPages}
                 </span>
                 <Button
                   variant="outline"
@@ -263,19 +263,18 @@ export default function MyEventsPage() {
       <Dialog open={!!deletingEvent} onOpenChange={() => setDeletingEvent(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete Event</DialogTitle>
+            <DialogTitle>Ta bort evenemang</DialogTitle>
             <DialogDescription>
-              Are you sure you want to delete &quot;{deletingEvent?.title}&quot;? This action cannot
-              be undone.
+              Är du säker på att du vill ta bort &quot;{deletingEvent?.title}&quot;? Det går inte att ångra.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setDeletingEvent(null)}>
-              Cancel
+              Avbryt
             </Button>
             <Button variant="destructive" onClick={handleDeleteConfirm} disabled={isDeleting}>
               {isDeleting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-              Delete
+              Ta bort
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -42,10 +42,10 @@ type EditField = {
 };
 
 const EDIT_FIELDS: EditField[] = [
-  { key: "fullName", label: "Full Name" },
-  { key: "phoneNumber", label: "Phone Number", inputType: "tel" },
-  { key: "businessName", label: "Business Name" },
-  { key: "organisationNumber", label: "Organisation Number" },
+  { key: "fullName", label: "Fullständigt namn" },
+  { key: "phoneNumber", label: "Telefonnummer", inputType: "tel" },
+  { key: "businessName", label: "Företagsnamn" },
+  { key: "organisationNumber", label: "Organisationsnummer" },
 ];
 
 function ProfileRow({
@@ -123,7 +123,7 @@ export default function ProfilePage() {
           setProfile(res.data.data);
         }
       } catch {
-        toast.error("Failed to load profile. Please log in again.");
+        toast.error("Det gick inte att hämta profilen. Logga in igen.");
       } finally {
         setIsLoading(false);
       }
@@ -147,14 +147,14 @@ export default function ProfilePage() {
       });
       if (res.data.isSuccess && res.data.data) {
         setProfile((prev) => (prev ? { ...prev, ...res.data.data } : prev));
-        toast.success(`${editField.label} updated`);
+        toast.success(`${editField.label} uppdaterades`);
         setEditField(null);
       } else {
-        toast.error(res.data.errors?.join(", ") || "Failed to update");
+        toast.error(res.data.errors?.join(", ") || "Det gick inte att uppdatera");
       }
     } catch (e: unknown) {
       const err = e as { response?: { data?: OperationResult<unknown> } };
-      toast.error(err?.response?.data?.errors?.join(", ") || "Failed to update");
+      toast.error(err?.response?.data?.errors?.join(", ") || "Det gick inte att uppdatera");
     } finally {
       setIsSaving(false);
     }
@@ -162,7 +162,7 @@ export default function ProfilePage() {
 
   const handleChangePassword = async () => {
     if (passwordForm.newPassword !== passwordForm.confirmNewPassword) {
-      toast.error("New passwords do not match");
+      toast.error("De nya lösenorden matchar inte");
       return;
     }
     setIsChangingPassword(true);
@@ -173,15 +173,15 @@ export default function ProfilePage() {
         confirmNewPassword: passwordForm.confirmNewPassword,
       });
       if (res.data.isSuccess) {
-        toast.success("Password changed successfully");
+        toast.success("Lösenordet har ändrats");
         setChangePasswordOpen(false);
         setPasswordForm({ currentPassword: "", newPassword: "", confirmNewPassword: "" });
       } else {
-        toast.error(res.data.errors?.join(", ") || "Failed to change password");
+        toast.error(res.data.errors?.join(", ") || "Det gick inte att ändra lösenordet");
       }
     } catch (e: unknown) {
       const err = e as { response?: { data?: OperationResult<unknown> } };
-      toast.error(err?.response?.data?.errors?.join(", ") || "Failed to change password");
+      toast.error(err?.response?.data?.errors?.join(", ") || "Det gick inte att ändra lösenordet");
     } finally {
       setIsChangingPassword(false);
     }
@@ -200,14 +200,14 @@ export default function ProfilePage() {
       });
       if (res.data.isSuccess) {
         localStorage.removeItem("accessToken");
-        toast.success("Account deleted");
+        toast.success("Kontot har tagits bort");
         router.replace("/login");
       } else {
-        toast.error(res.data.errors?.join(", ") || "Failed to delete account");
+        toast.error(res.data.errors?.join(", ") || "Det gick inte att ta bort kontot");
       }
     } catch (e: unknown) {
       const err = e as { response?: { data?: OperationResult<unknown> } };
-      toast.error(err?.response?.data?.errors?.join(", ") || "Failed to delete account");
+      toast.error(err?.response?.data?.errors?.join(", ") || "Det gick inte att ta bort kontot");
     } finally {
       setIsDeleting(false);
     }
@@ -244,7 +244,7 @@ export default function ProfilePage() {
         </div>
 
         {/* Account Details */}
-        <SectionCard title="My Account">
+        <SectionCard title="Mitt konto">
           {EDIT_FIELDS.map((field) => (
             <ProfileRow
               key={field.key}
@@ -256,9 +256,9 @@ export default function ProfilePage() {
         </SectionCard>
 
         {/* Security */}
-        <SectionCard title="Security">
+        <SectionCard title="Säkerhet">
           <ProfileRow
-            label="Change Password"
+            label="Ändra lösenord"
             onClick={() => setChangePasswordOpen(true)}
           />
           <button
@@ -266,7 +266,7 @@ export default function ProfilePage() {
             onClick={() => setDeleteOpen(true)}
             className="w-full flex items-center justify-between py-3.5 px-1 hover:bg-gray-50 transition-colors"
           >
-            <span className="text-sm font-medium text-red-600">Delete Account</span>
+            <span className="text-sm font-medium text-red-600">Ta bort konto</span>
             <ChevronRight className="w-4 h-4 text-red-400 shrink-0" />
           </button>
         </SectionCard>
@@ -278,7 +278,7 @@ export default function ProfilePage() {
             onClick={handleLogout}
             className="w-full py-3 rounded-[26px] border-2 border-red-600 text-red-600 text-sm font-semibold hover:bg-red-50 transition-colors"
           >
-            Log Out
+            Logga ut
           </button>
         </div>
       </section>
@@ -291,7 +291,7 @@ export default function ProfilePage() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{editField?.label}</DialogTitle>
-            <DialogDescription>Update your {editField?.label?.toLowerCase()}.</DialogDescription>
+            <DialogDescription>Uppdatera {editField?.label?.toLowerCase()}.</DialogDescription>
           </DialogHeader>
           <div className="py-2">
             <Label htmlFor="editFieldInput">{editField?.label}</Label>
@@ -305,7 +305,7 @@ export default function ProfilePage() {
           </div>
           <DialogFooter>
             <Button variant="outline" className="rounded-[26px] hover:bg-gray-100 hover:text-[#1C1C1E]" onClick={() => setEditField(null)}>
-              Cancel
+              Avbryt
             </Button>
             <Button
               className="rounded-[26px] bg-[#F3C10E] text-[#2A2000] hover:bg-[#EDB80D]"
@@ -313,7 +313,7 @@ export default function ProfilePage() {
               disabled={isSaving}
             >
               {isSaving && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-              Save
+              Spara
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -329,12 +329,12 @@ export default function ProfilePage() {
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Change Password</DialogTitle>
-            <DialogDescription>Enter your current password and choose a new one.</DialogDescription>
+            <DialogTitle>Ändra lösenord</DialogTitle>
+            <DialogDescription>Ange ditt nuvarande lösenord och välj ett nytt.</DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-2">
             <div>
-              <Label htmlFor="currentPassword">Current Password</Label>
+              <Label htmlFor="currentPassword">Nuvarande lösenord</Label>
               <Input
                 id="currentPassword"
                 type="password"
@@ -344,7 +344,7 @@ export default function ProfilePage() {
               />
             </div>
             <div>
-              <Label htmlFor="newPassword">New Password</Label>
+              <Label htmlFor="newPassword">Nytt lösenord</Label>
               <Input
                 id="newPassword"
                 type="password"
@@ -354,7 +354,7 @@ export default function ProfilePage() {
               />
             </div>
             <div>
-              <Label htmlFor="confirmNewPassword">Confirm New Password</Label>
+              <Label htmlFor="confirmNewPassword">Bekräfta nytt lösenord</Label>
               <Input
                 id="confirmNewPassword"
                 type="password"
@@ -366,7 +366,7 @@ export default function ProfilePage() {
           </div>
           <DialogFooter>
             <Button variant="outline" className="rounded-[26px] hover:bg-gray-100 hover:text-[#1C1C1E]" onClick={() => setChangePasswordOpen(false)}>
-              Cancel
+              Avbryt
             </Button>
             <Button
               className="rounded-[26px] bg-[#F3C10E] text-[#2A2000] hover:bg-[#EDB80D]"
@@ -379,7 +379,7 @@ export default function ProfilePage() {
               }
             >
               {isChangingPassword && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-              Change Password
+              Ändra lösenord
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -395,13 +395,13 @@ export default function ProfilePage() {
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete Account</DialogTitle>
+            <DialogTitle>Ta bort konto</DialogTitle>
             <DialogDescription>
-              This will permanently delete your account and all associated data. This cannot be undone.
+              Det här raderar ditt konto och all tillhörande data permanent. Det går inte att ångra.
             </DialogDescription>
           </DialogHeader>
           <div className="py-2">
-            <Label htmlFor="deletePassword">Enter your password to confirm</Label>
+            <Label htmlFor="deletePassword">Ange ditt lösenord för att bekräfta</Label>
             <Input
               id="deletePassword"
               type="password"
@@ -412,7 +412,7 @@ export default function ProfilePage() {
           </div>
           <DialogFooter>
             <Button variant="outline" className="rounded-[26px] hover:bg-gray-100 hover:text-[#1C1C1E]" onClick={() => setDeleteOpen(false)}>
-              Cancel
+              Avbryt
             </Button>
             <Button
               variant="destructive"
@@ -421,7 +421,7 @@ export default function ProfilePage() {
               disabled={isDeleting || !deletePassword}
             >
               {isDeleting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-              Delete Account
+              Ta bort konto
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/app/quick-create/page.tsx
+++ b/src/app/quick-create/page.tsx
@@ -74,8 +74,8 @@ export default function QuickCreatePage() {
           <div className="flex items-start gap-3 text-black">
             <CheckCircle className="text-green-500 mt-1" />
             <div>
-              <p className="font-semibold">Place created!</p>
-              <p className="text-sm">Added as always-open attraction on Go.Do.</p>
+              <p className="font-semibold">Platsen skapades!</p>
+              <p className="text-sm">Tillagd som alltid öppen attraktion på Go.Do.</p>
             </div>
           </div>
         );
@@ -83,12 +83,12 @@ export default function QuickCreatePage() {
       onError: (error: unknown) => {
         const axiosError = error as { response?: { data?: { errors?: string[] } } };
         const message =
-          axiosError?.response?.data?.errors?.[0] || "Please check your input and try again.";
+          axiosError?.response?.data?.errors?.[0] || "Kontrollera dina uppgifter och försök igen.";
         toast(
           <div className="flex items-start gap-3 text-black">
             <XCircle className="text-red-500 mt-1" />
             <div>
-              <p className="font-semibold">Creation failed</p>
+              <p className="font-semibold">Det gick inte att skapa platsen</p>
               <p className="text-sm">{message}</p>
             </div>
           </div>
@@ -105,7 +105,7 @@ export default function QuickCreatePage() {
         <section className="flex-1 flex items-center justify-center">
           <div className="flex flex-col items-center gap-4">
             <Loader2 className="w-8 h-8 animate-spin" />
-            <p>Checking permissions...</p>
+            <p>Kontrollerar behörigheter...</p>
           </div>
         </section>
       </main>
@@ -121,16 +121,16 @@ export default function QuickCreatePage() {
           <Card className="max-w-md bg-white shadow-lg">
             <CardContent className="pt-6 text-center space-y-4">
               <ShieldX className="w-16 h-16 text-red-500 mx-auto" />
-              <h2 className="text-2xl font-bold">Access Denied</h2>
+              <h2 className="text-2xl font-bold">Åtkomst nekad</h2>
               <p className="text-gray-600">
-                This page is only accessible to administrators.
+                Den här sidan är endast tillgänglig för administratörer.
               </p>
               <Button
                 onClick={() => router.push("/landing")}
                 className="w-full bg-black text-white hover:bg-black/90"
               >
                 <ArrowLeft className="w-4 h-4 mr-2" />
-                Back to Home
+                Tillbaka till startsidan
               </Button>
             </CardContent>
           </Card>
@@ -149,13 +149,13 @@ export default function QuickCreatePage() {
             <Zap className="w-6 h-6" />
           </div>
           <div>
-            <h1 className="text-3xl font-bold">Quick Create</h1>
-            <p className="text-sm text-gray-700">Add places & attractions on the go</p>
+            <h1 className="text-3xl font-bold">Snabbskapa</h1>
+            <p className="text-sm text-gray-700">Lägg till platser och attraktioner snabbt</p>
           </div>
         </div>
 
         {/* Admin badge */}
-        <div className="mb-6 bg-black text-white text-xs px-3 py-1 rounded-full">Admin Only</div>
+        <div className="mb-6 bg-black text-white text-xs px-3 py-1 rounded-full">Endast admin</div>
 
         <div className="w-full max-w-2xl">
           {formSubmitted && submittedData ? (
@@ -166,8 +166,8 @@ export default function QuickCreatePage() {
                 <div className="bg-green-500 text-white px-6 py-4 flex items-center gap-3">
                   <CheckCircle className="w-8 h-8" />
                   <div>
-                    <h2 className="text-xl font-bold">Successfully Added!</h2>
-                    <p className="text-sm opacity-90">Place is now live on Go.Do.</p>
+                    <h2 className="text-xl font-bold">Tillagd!</h2>
+                    <p className="text-sm opacity-90">Platsen är nu live på Go.Do.</p>
                   </div>
                 </div>
 
@@ -176,14 +176,14 @@ export default function QuickCreatePage() {
                   <div className="space-y-3">
                     {submittedData.name && (
                       <div>
-                        <p className="text-xs text-gray-500 uppercase tracking-wide">Name</p>
+                        <p className="text-xs text-gray-500 uppercase tracking-wide">Namn</p>
                         <p className="text-lg font-semibold">{submittedData.name}</p>
                       </div>
                     )}
 
                     {(submittedData.place || submittedData.address) && (
                       <div>
-                        <p className="text-xs text-gray-500 uppercase tracking-wide">Location</p>
+                        <p className="text-xs text-gray-500 uppercase tracking-wide">Plats</p>
                         <p className="font-medium">
                           {[submittedData.address, submittedData.place].filter(Boolean).join(", ")}
                         </p>
@@ -192,14 +192,14 @@ export default function QuickCreatePage() {
 
                     {submittedData.organiserName && (
                       <div>
-                        <p className="text-xs text-gray-500 uppercase tracking-wide">Owner</p>
+                        <p className="text-xs text-gray-500 uppercase tracking-wide">Ägare</p>
                         <p className="font-medium">{submittedData.organiserName}</p>
                       </div>
                     )}
 
                     {submittedData.description && (
                       <div>
-                        <p className="text-xs text-gray-500 uppercase tracking-wide">Description</p>
+                        <p className="text-xs text-gray-500 uppercase tracking-wide">Beskrivning</p>
                         <p className="text-sm text-gray-700 line-clamp-3">
                           {submittedData.description}
                         </p>
@@ -210,17 +210,17 @@ export default function QuickCreatePage() {
                   {/* Tags */}
                   <div className="flex flex-wrap gap-2 pt-2 border-t">
                     <span className="bg-yellow-100 text-yellow-800 text-xs px-2 py-1 rounded-full">
-                      Always Open
+                      Alltid öppet
                     </span>
                     {submittedData.subcategoryCodes &&
                       submittedData.subcategoryCodes.length > 0 && (
                         <span className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full">
-                          {submittedData.subcategoryCodes.length} categories
+                          {submittedData.subcategoryCodes.length} kategorier
                         </span>
                       )}
                     {submittedData.filterCodes && submittedData.filterCodes.length > 0 && (
                       <span className="bg-purple-100 text-purple-800 text-xs px-2 py-1 rounded-full">
-                        {submittedData.filterCodes.length} filters
+                        {submittedData.filterCodes.length} filter
                       </span>
                     )}
                   </div>
@@ -234,7 +234,7 @@ export default function QuickCreatePage() {
                   className="w-full bg-black text-white hover:bg-black/90 flex items-center justify-center gap-2 h-12"
                 >
                   <Plus className="w-5 h-5" />
-                  Add Another Place
+                  Lägg till en till plats
                 </Button>
 
                 <div className="flex gap-3">
@@ -244,7 +244,7 @@ export default function QuickCreatePage() {
                     className="flex-1 border-black/20 hover:bg-white/50 flex items-center justify-center gap-2"
                   >
                     <ArrowLeft className="w-4 h-4" />
-                    Back to Start
+                    Tillbaka till start
                   </Button>
                   <Button
                     onClick={handleLogout}
@@ -252,7 +252,7 @@ export default function QuickCreatePage() {
                     className="flex-1 border-red-300 text-red-600 hover:bg-red-50 flex items-center justify-center gap-2"
                   >
                     <LogOut className="w-4 h-4" />
-                    Logout
+                    Logga ut
                   </Button>
                 </div>
               </div>

--- a/src/components/forms/EventFormStepper.tsx
+++ b/src/components/forms/EventFormStepper.tsx
@@ -76,7 +76,7 @@ export function EventFormStepper({ step, nextStep, prevStep, onSubmit }: EventFo
 
       <div className="flex justify-between pt-4">
         <Button type="button" variant="outline" onClick={prevStep} disabled={step === 0}>
-          Back
+          Tillbaka
         </Button>
         {step < LAST_STEP ? (
           <TooltipProvider>
@@ -84,20 +84,20 @@ export function EventFormStepper({ step, nextStep, prevStep, onSubmit }: EventFo
               <TooltipTrigger asChild>
                 <span>
                   <Button type="button" onClick={handleNext} disabled={!isStepFilled}>
-                    Next
+                    Nästa
                   </Button>
                 </span>
               </TooltipTrigger>
               {!isStepFilled && (
                 <TooltipContent>
-                  Please fill out all required fields before continuing.
+                  Fyll i alla obligatoriska fält innan du fortsätter.
                 </TooltipContent>
               )}
             </Tooltip>
           </TooltipProvider>
         ) : (
           <Button type="submit" className="bg-black text-white hover:bg-gray-800">
-            Submit
+            Skicka in
           </Button>
         )}
       </div>

--- a/src/components/forms/QuickCreateForm.tsx
+++ b/src/components/forms/QuickCreateForm.tsx
@@ -57,15 +57,15 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
         <CardContent className="pt-6 space-y-4">
           <div className="flex items-center gap-2 text-lg font-semibold mb-4">
             <Building2 className="w-5 h-5" />
-            <span>Basic Info</span>
+            <span>Grundinformation</span>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="name">Place/Attraction Name</Label>
+              <Label htmlFor="name">Plats-/attraktionsnamn</Label>
               <Input
                 id="name"
-                placeholder="e.g., Helsingborg Castle"
+                placeholder="t.ex. Helsingborgs slott"
                 {...register("name")}
                 className="bg-white"
               />
@@ -73,10 +73,10 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="organiserName">Owner/Organiser</Label>
+              <Label htmlFor="organiserName">Ägare/Arrangör</Label>
               <Input
                 id="organiserName"
-                placeholder="e.g., City of Helsingborg"
+                placeholder="t.ex. Helsingborgs stad"
                 {...register("organiserName")}
                 className="bg-white"
               />
@@ -86,10 +86,10 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="organisationNumber">Organisation Number</Label>
+              <Label htmlFor="organisationNumber">Organisationsnummer</Label>
               <Input
                 id="organisationNumber"
-                placeholder="e.g., 556677-8899"
+                placeholder="t.ex. 556677-8899"
                 {...register("organisationNumber")}
                 className="bg-white"
               />
@@ -99,7 +99,7 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="readMoreUrl">Website URL</Label>
+              <Label htmlFor="readMoreUrl">Webbplatsadress</Label>
               <Input
                 id="readMoreUrl"
                 placeholder="https://..."
@@ -119,15 +119,15 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
         <CardContent className="pt-6 space-y-4">
           <div className="flex items-center gap-2 text-lg font-semibold mb-4">
             <MapPin className="w-5 h-5" />
-            <span>Location</span>
+            <span>Plats</span>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="place">City/Place</Label>
+              <Label htmlFor="place">Stad/Plats</Label>
               <Input
                 id="place"
-                placeholder="e.g., Helsingborg"
+                placeholder="t.ex. Helsingborg"
                 {...register("place")}
                 className="bg-white"
               />
@@ -135,10 +135,10 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="address">Address</Label>
+              <Label htmlFor="address">Adress</Label>
               <Input
                 id="address"
-                placeholder="e.g., Slottshagen 1"
+                placeholder="t.ex. Slottshagen 1"
                 {...register("address")}
                 className="bg-white"
               />
@@ -146,10 +146,10 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
             </div>
 
             <div className="space-y-2 md:col-span-2">
-              <Label htmlFor="gpsCoordinates">GPS Coordinates</Label>
+              <Label htmlFor="gpsCoordinates">GPS-koordinater</Label>
               <Input
                 id="gpsCoordinates"
-                placeholder="e.g., 56.0465, 12.6945"
+                placeholder="t.ex. 56.0465, 12.6945"
                 {...register("gpsCoordinates")}
                 className="bg-white"
               />
@@ -166,14 +166,14 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
         <CardContent className="pt-6 space-y-4">
           <div className="flex items-center gap-2 text-lg font-semibold mb-4">
             <FileText className="w-5 h-5" />
-            <span>Description</span>
+            <span>Beskrivning</span>
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="description">Description</Label>
+            <Label htmlFor="description">Beskrivning</Label>
             <Textarea
               id="description"
-              placeholder="Describe the place or attraction..."
+              placeholder="Beskriv platsen eller attraktionen..."
               rows={4}
               {...register("description")}
               className="bg-white resize-none"
@@ -190,11 +190,11 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
         <CardContent className="pt-6 space-y-4">
           <div className="flex items-center gap-2 text-lg font-semibold mb-4">
             <Tag className="w-5 h-5" />
-            <span>Categories</span>
+            <span>Kategorier</span>
           </div>
 
           <div className="space-y-4">
-            <Label>Select Subcategories (optional)</Label>
+            <Label>Välj underkategorier (valfritt)</Label>
             <div className="flex flex-wrap gap-2">
               {allSubcategories.map((sub) => (
                 <Button
@@ -215,7 +215,7 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
             </div>
             {selectedSubcategories.length > 0 && (
               <p className="text-sm text-gray-600">
-                Selected: {selectedSubcategories.length} subcategories
+                Valda: {selectedSubcategories.length} underkategorier
               </p>
             )}
           </div>
@@ -227,11 +227,11 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
         <CardContent className="pt-6 space-y-4">
           <div className="flex items-center gap-2 text-lg font-semibold mb-4">
             <Zap className="w-5 h-5" />
-            <span>Filters</span>
+            <span>Filter</span>
           </div>
 
           <div className="space-y-4">
-            <Label>Select Filters (optional)</Label>
+            <Label>Välj filter (valfritt)</Label>
             <div className="flex flex-wrap gap-2">
               {filterOptions.map((filter) => (
                 <Button
@@ -261,11 +261,11 @@ export function QuickCreateForm({ form, onSubmit, isLoading }: QuickCreateFormPr
       >
         {isLoading ? (
           <span className="flex items-center gap-2">
-            <span className="animate-spin">⏳</span> Creating...
+            <span className="animate-spin">⏳</span> Skapar...
           </span>
         ) : (
           <span className="flex items-center gap-2">
-            <Zap className="w-5 h-5" /> Quick Create
+            <Zap className="w-5 h-5" /> Snabbskapa
           </span>
         )}
       </Button>

--- a/src/components/forms/TimePicker.tsx
+++ b/src/components/forms/TimePicker.tsx
@@ -14,12 +14,8 @@ type TimeOption = { value: string; label: string };
 const timeOptions: TimeOption[] = Array.from({ length: 24 * 2 }, (_, i) => {
   const h = Math.floor(i / 2);
   const m = i % 2 === 0 ? "00" : "30";
-  const raw = `${h.toString().padStart(2, "0")}:${m}:00`;
-  const display = new Date(`1970-01-01T${raw}`).toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: true,
-  });
+  const raw = `${h.toString().padStart(2, "0")}:${m}`;
+  const display = `${h.toString().padStart(2, "0")}:${m}`;
   return { value: raw, label: display };
 });
 
@@ -50,7 +46,7 @@ export function TimePicker({
       <Select value={value} onValueChange={handleValueChange}>
         <SelectTrigger className="w-full">
           <Clock className="w-4 h-4 mr-2 text-muted-foreground" />
-          <SelectValue placeholder={placeholder || "Pick time"} />
+          <SelectValue placeholder={placeholder || "Välj tid"} />
         </SelectTrigger>
         <SelectContent className="max-h-48 overflow-y-auto">
           {timeOptions.map((t) => {

--- a/src/components/forms/steps/StepEventDateTime.tsx
+++ b/src/components/forms/steps/StepEventDateTime.tsx
@@ -19,13 +19,13 @@ interface Props {
 }
 
 const WEEKDAYS = [
-  { value: "mon", label: "Mon" },
-  { value: "tue", label: "Tue" },
-  { value: "wed", label: "Wed" },
-  { value: "thu", label: "Thu" },
-  { value: "fri", label: "Fri" },
-  { value: "sat", label: "Sat" },
-  { value: "sun", label: "Sun" },
+  { value: "mon", label: "Mån" },
+  { value: "tue", label: "Tis" },
+  { value: "wed", label: "Ons" },
+  { value: "thu", label: "Tor" },
+  { value: "fri", label: "Fre" },
+  { value: "sat", label: "Lör" },
+  { value: "sun", label: "Sön" },
 ];
 
 const WEEKDAY_LABELS: Record<string, string> = {
@@ -54,13 +54,13 @@ function RecurringSummary({
     startDate && endDate
       ? `${format(startDate, "dd.MM.yyyy")} → ${format(endDate, "dd.MM.yyyy")}`
       : startDate
-        ? `from ${format(startDate, "dd.MM.yyyy")}`
+        ? `från ${format(startDate, "dd.MM.yyyy")}`
         : null;
   const timeRange =
     scheduleStartTime && scheduleEndTime
       ? `${scheduleStartTime} – ${scheduleEndTime}`
       : scheduleStartTime
-        ? `from ${scheduleStartTime}`
+        ? `från ${scheduleStartTime}`
         : null;
 
   return (
@@ -143,23 +143,23 @@ export function StepEventDateTime({ control, errors }: Props) {
   return (
     <div className="space-y-6">
       <div>
-        <Label className="mb-4 block">Select Timing Type</Label>
+        <Label className="mb-4 block">Välj tidstyp</Label>
         <RadioGroup value={selected} onValueChange={handleTimingChange} className="flex flex-wrap gap-4">
           <div className="flex items-center space-x-2 py-2">
             <RadioGroupItem value="single" id="single" />
-            <Label htmlFor="single" className="text-base">Single instance</Label>
+            <Label htmlFor="single" className="text-base">Enstaka tillfälle</Label>
           </div>
           <div className="flex items-center space-x-2 py-2">
             <RadioGroupItem value="multiple" id="multiple" />
-            <Label htmlFor="multiple" className="text-base">Multiple dates</Label>
+            <Label htmlFor="multiple" className="text-base">Flera datum</Label>
           </div>
           <div className="flex items-center space-x-2 py-2">
             <RadioGroupItem value="recurring" id="recurring" />
-            <Label htmlFor="recurring" className="text-base">Recurring (weekly)</Label>
+            <Label htmlFor="recurring" className="text-base">Återkommande (veckovis)</Label>
           </div>
           <div className="flex items-center space-x-2 py-2">
             <RadioGroupItem value="always" id="always" />
-            <Label htmlFor="always" className="text-base">Always Open</Label>
+            <Label htmlFor="always" className="text-base">Alltid öppet</Label>
           </div>
         </RadioGroup>
       </div>
@@ -168,7 +168,7 @@ export function StepEventDateTime({ control, errors }: Props) {
       {selected === "single" && (
         <div className="flex flex-col sm:flex-row sm:items-start sm:gap-6">
           <div>
-            <Label className="block mb-2">Select date</Label>
+            <Label className="block mb-2">Välj datum</Label>
             <Calendar
               mode="single"
               selected={startDate}
@@ -190,7 +190,7 @@ export function StepEventDateTime({ control, errors }: Props) {
                 value={field.value}
                 onChange={field.onChange}
                 placeholder="Start"
-                label="Start Time"
+                label="Starttid"
               />
             )}
           />
@@ -201,8 +201,8 @@ export function StepEventDateTime({ control, errors }: Props) {
               <TimePicker
                 value={field.value}
                 onChange={field.onChange}
-                placeholder="End"
-                label="End Time"
+                placeholder="Slut"
+                label="Sluttid"
                 disabledOptions={(opt) => (startTime ? opt <= startTime : false)}
               />
             )}
@@ -239,7 +239,7 @@ export function StepEventDateTime({ control, errors }: Props) {
 
           <div className="flex flex-col sm:flex-row sm:items-start sm:gap-6">
             <div>
-              <Label className="block mb-2">Select date range</Label>
+              <Label className="block mb-2">Välj datumintervall</Label>
               <Calendar
                 mode="range"
                 selected={tempRange}
@@ -251,13 +251,13 @@ export function StepEventDateTime({ control, errors }: Props) {
               value={tempStartTime}
               onChange={setTempStartTime}
               placeholder="Start"
-              label="Start Time"
+              label="Starttid"
             />
             <TimePicker
               value={tempEndTime}
               onChange={setTempEndTime}
-              placeholder="End"
-              label="End Time"
+              placeholder="Slut"
+              label="Sluttid"
               disabledOptions={(opt) => {
                 if (
                   tempRange?.from &&
@@ -349,7 +349,7 @@ export function StepEventDateTime({ control, errors }: Props) {
 
           <div className="flex flex-col sm:flex-row sm:items-start sm:gap-6">
             <div>
-              <Label className="block mb-2">Select date range</Label>
+              <Label className="block mb-2">Välj datumintervall</Label>
               <Calendar
                 mode="range"
                 selected={{ from: startDate, to: endDate }}
@@ -371,7 +371,7 @@ export function StepEventDateTime({ control, errors }: Props) {
                   value={field.value}
                   onChange={field.onChange}
                   placeholder="Start"
-                  label="Start Time"
+                  label="Starttid"
                 />
               )}
             />
@@ -382,8 +382,8 @@ export function StepEventDateTime({ control, errors }: Props) {
                 <TimePicker
                   value={field.value}
                   onChange={field.onChange}
-                  placeholder="End"
-                  label="End Time"
+                  placeholder="Slut"
+                  label="Sluttid"
                   disabledOptions={(opt) => (scheduleStartTime ? opt <= scheduleStartTime : false)}
                 />
               )}
@@ -428,10 +428,9 @@ export function StepEventDateTime({ control, errors }: Props) {
 
       {/* Always Open */}
       {selected === "always" && (
-        <p className="text-muted-foreground italic">This event will be listed as always open.</p>
+        <p className="text-muted-foreground italic">Det här evenemanget visas som alltid öppet.</p>
       )}
 
-      <p className="text-xs text-muted-foreground italic">* Not all fields above are required</p>
     </div>
   );
 }

--- a/src/components/forms/steps/StepEventDetails.tsx
+++ b/src/components/forms/steps/StepEventDetails.tsx
@@ -64,15 +64,15 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
     <div className="space-y-4">
       <div>
         <Label className="py-2 block">
-          Organiser <span className="text-red-500">*</span>
+          Arrangör <span className="text-red-500">*</span>
         </Label>
-        <Input placeholder="Organiser name" {...register("organiser")} />
+        <Input placeholder="Arrangörens namn" {...register("organiser")} />
         {errors.organiser && <p className="text-red-500 text-sm">{errors.organiser.message}</p>}
       </div>
 
       <div>
         <Label className="py-2 block">
-          Organisation number <span className="text-red-500">*</span>
+          Organisationsnummer <span className="text-red-500">*</span>
         </Label>
         <Input
           placeholder="XXXXXX-XXXX"
@@ -81,7 +81,7 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
           className={orgNrLocked ? "bg-gray-100 cursor-default select-none" : ""}
         />
         {orgNrLocked && (
-          <p className="text-xs text-muted-foreground mt-1">Auto-filled from your account</p>
+          <p className="text-xs text-muted-foreground mt-1">Hämtad från ditt konto</p>
         )}
         {errors.organisationNumber && (
           <p className="text-red-500 text-sm">{errors.organisationNumber.message}</p>
@@ -90,19 +90,19 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
 
       <div>
         <Label className="py-2 block">
-          Title <span className="text-red-500">*</span>
+          Titel <span className="text-red-500">*</span>
         </Label>
-        <Input placeholder="Event Title" {...register("title")} />
+        <Input placeholder="Evenemangets titel" {...register("title")} />
         {errors.title && <p className="text-red-500 text-sm">{errors.title.message}</p>}
       </div>
 
       {/* Categories + Subcategories */}
       <div>
         <Label className="py-2 block">
-          Select Categories <span className="text-red-500">*</span>
+          Välj kategorier <span className="text-red-500">*</span>
         </Label>
         <p className="text-xs text-muted-foreground mb-3">
-          Max {MAX_CATEGORIES} categories — click a selected category to open subcategories
+          Max {MAX_CATEGORIES} kategorier — klicka på en vald kategori för att öppna underkategorier
         </p>
         <Controller
           name="categories"
@@ -188,7 +188,7 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
                               <div className="w-full bg-white border rounded-lg p-4 shadow">
                                 <p className="text-sm font-semibold mb-2 text-gray-700">
                                   {categoryOptions.find((c) => c.code === openDropdown)?.label}{" "}
-                                  Subcategories
+                                  Underkategorier
                                 </p>
                                 <div className="flex flex-wrap gap-3 max-h-48 overflow-y-auto scroll-smooth p-1.5">
                                   {subcategoriesMap[openDropdown]?.map(
@@ -243,8 +243,8 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
                                   >
                                     {subField.value?.[openDropdown]?.length ===
                                     subcategoriesMap[openDropdown]?.length
-                                      ? "Unselect All"
-                                      : "Select All"}
+                                      ? "Avmarkera alla"
+                                      : "Välj alla"}
                                   </Button>
                                 </div>
                               </div>
@@ -263,7 +263,7 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
 
       {/* Filters */}
       <div>
-        <Label className="py-2 block">Filters</Label>
+        <Label className="py-2 block">Filter</Label>
         <Controller
           name="filters"
           control={control}
@@ -303,24 +303,23 @@ export function StepEventDetails({ register, control, errors }: StepDetailsProps
       {/* Description & URLs */}
       <div>
         <Label className="py-2 block">
-          Description <span className="text-red-500">*</span>
+          Beskrivning <span className="text-red-500">*</span>
         </Label>
-        <Textarea placeholder="Event Description" {...register("description")} />
+        <Textarea placeholder="Beskrivning av evenemanget" {...register("description")} />
         {errors.description && <p className="text-red-500 text-sm">{errors.description.message}</p>}
       </div>
 
       <div>
-        <Label className="py-2 block">Event URL</Label>
+        <Label className="py-2 block">Evenemangslänk</Label>
         <Input placeholder="https://event-link.com" {...register("eventUrl")} />
         {errors.eventUrl && <p className="text-red-500 text-sm">{errors.eventUrl.message}</p>}
       </div>
 
       <div>
-        <Label className="py-2 block">Booking URL</Label>
+        <Label className="py-2 block">Bokningslänk</Label>
         <Input placeholder="https://booking-link.com" {...register("bookingUrl")} />
         {errors.bookingUrl && <p className="text-red-500 text-sm">{errors.bookingUrl.message}</p>}
       </div>
-      <p className="text-xs text-muted-foreground italic">* Not all fields above are required</p>
     </div>
   );
 }

--- a/src/components/forms/steps/StepEventLocation.tsx
+++ b/src/components/forms/steps/StepEventLocation.tsx
@@ -17,23 +17,17 @@ export function StepEventLocation({ register, errors }: StepEventLocationProps) 
     <div className="space-y-4">
       <div>
         <Label className="py-2">
-          Street Name <span className="text-red-500">*</span>
+          Gatunamn <span className="text-red-500">*</span>
         </Label>
-        <Input placeholder="Street name" {...register("streetName")} />
+        <Input placeholder="Gatunamn" {...register("streetName")} />
         {errors.streetName && <p className="text-red-500 text-sm">{errors.streetName.message}</p>}
       </div>
 
       <div>
-        <Label className="py-2">Street Name 2</Label>
-        <Input placeholder="Apartment, suite, etc." {...register("streetName2")} />
-        {errors.streetName2 && <p className="text-red-500 text-sm">{errors.streetName2.message}</p>}
-      </div>
-
-      <div>
-        <Label className="py-2">House Number</Label>
+        <Label className="py-2">Gatunummer</Label>
         <Input
           type="number"
-          placeholder="123"
+          placeholder="t.ex. 12"
           {...register("houseNumber", { valueAsNumber: true })}
         />
         {errors.houseNumber && <p className="text-red-500 text-sm">{errors.houseNumber.message}</p>}
@@ -41,15 +35,15 @@ export function StepEventLocation({ register, errors }: StepEventLocationProps) 
 
       <div>
         <Label className="py-2">
-          City <span className="text-red-500">*</span>
+          Stad <span className="text-red-500">*</span>
         </Label>
-        <Input placeholder="City name" {...register("city")} />
+        <Input placeholder="Stadsnamn" {...register("city")} />
         {errors.city && <p className="text-red-500 text-sm">{errors.city.message}</p>}
       </div>
 
       <div>
         <Label className="py-2">
-          Postal Code <span className="text-red-500">*</span>
+          Postnummer <span className="text-red-500">*</span>
         </Label>
         <Input placeholder="12345" {...register("postalCode")} />
         {errors.postalCode && <p className="text-red-500 text-sm">{errors.postalCode.message}</p>}
@@ -57,17 +51,17 @@ export function StepEventLocation({ register, errors }: StepEventLocationProps) 
 
       <div>
         <div className="flex items-center gap-1.5 py-2">
-          <Label>GPS Coordinates</Label>
+          <Label>GPS-koordinater</Label>
           <button
             type="button"
             onClick={() => setShowGpsInfo((v) => !v)}
             className="text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="Show GPS help"
+            aria-label="Visa GPS-hjälp"
           >
             <Info className="w-4 h-4" />
           </button>
         </div>
-        <Input placeholder="e.g., 56.0465, 12.6945" {...register("gpsCoordinates")} />
+        <Input placeholder="t.ex. 56.0465, 12.6945" {...register("gpsCoordinates")} />
         {errors.gpsCoordinates && (
           <p className="text-red-500 text-sm">{errors.gpsCoordinates.message}</p>
         )}
@@ -85,7 +79,6 @@ export function StepEventLocation({ register, errors }: StepEventLocationProps) 
           </div>
         )}
       </div>
-      <p className="text-xs text-muted-foreground italic">* Not all fields above are required</p>
     </div>
   );
 }

--- a/src/components/forms/steps/StepEventReview.tsx
+++ b/src/components/forms/steps/StepEventReview.tsx
@@ -46,7 +46,7 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
 
   return (
     <div className="w-full max-w-xl space-y-4">
-      <h2 className="text-xl font-semibold text-center">Review your event info</h2>
+      <h2 className="text-xl font-semibold text-center">Granska ditt evenemang</h2>
 
       <Card className="bg-gray-50">
         <CardContent className="space-y-4 pt-6">
@@ -54,7 +54,7 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
             <div className="flex items-start gap-3">
               <Type className="w-5 h-5 mt-1 text-muted-foreground" />
               <div>
-                <Label className="text-muted-foreground">Event Title</Label>
+                <Label className="text-muted-foreground">Evenemangets titel</Label>
                 <p className="text-lg font-medium">{values.title}</p>
               </div>
             </div>
@@ -64,7 +64,7 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
             <div className="flex items-start gap-3">
               <User className="w-5 h-5 mt-1 text-muted-foreground" />
               <div>
-                <Label className="text-muted-foreground">Organiser</Label>
+                <Label className="text-muted-foreground">Arrangör</Label>
                 <p>{values.organiser}</p>
               </div>
             </div>
@@ -74,7 +74,7 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
             <div className="flex items-start gap-3">
               <User className="w-5 h-5 mt-1 text-muted-foreground" />
               <div>
-                <Label className="text-muted-foreground">Organisation number</Label>
+                <Label className="text-muted-foreground">Organisationsnummer</Label>
                 <p>{values.organisationNumber}</p>
               </div>
             </div>
@@ -84,7 +84,7 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
             <div className="flex items-start gap-3">
               <AlignLeft className="w-5 h-5 mt-1 text-muted-foreground" />
               <div>
-                <Label className="text-muted-foreground">Description</Label>
+                <Label className="text-muted-foreground">Beskrivning</Label>
                 <p>{values.description}</p>
               </div>
             </div>
@@ -94,7 +94,7 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
             <div className="flex items-start gap-3">
               <MapPin className="w-5 h-5 mt-1 text-muted-foreground" />
               <div>
-                <Label className="text-muted-foreground">Location</Label>
+                <Label className="text-muted-foreground">Plats</Label>
                 <p>
                   {[values.streetName, values.postalCode, values.city].filter(Boolean).join(", ")}
                 </p>
@@ -106,7 +106,7 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
             <div className="flex items-start gap-3">
               <Link className="w-5 h-5 mt-1 text-muted-foreground" />
               <div>
-                <Label className="text-muted-foreground">Event URL</Label>
+                <Label className="text-muted-foreground">Evenemangslänk</Label>
                 <p>{values.eventUrl}</p>
               </div>
             </div>
@@ -116,7 +116,7 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
             <div className="flex items-start gap-3">
               <Link className="w-5 h-5 mt-1 text-muted-foreground" />
               <div>
-                <Label className="text-muted-foreground">Booking URL</Label>
+                <Label className="text-muted-foreground">Bokningslänk</Label>
                 <p>{values.bookingUrl}</p>
               </div>
             </div>
@@ -127,7 +127,7 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
             <div className="flex items-start gap-3">
               <CalendarArrowDown className="w-5 h-5 mt-1 text-muted-foreground" />
               <div>
-                <Label className="text-muted-foreground">Start</Label>
+                <Label className="text-muted-foreground">Starttid</Label>
                 <div className="flex items-center gap-4">
                   {values.startDate && (
                     <div className="flex items-center gap-1">
@@ -150,7 +150,7 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
             <div className="flex items-start gap-3">
               <CalendarArrowUp className="w-5 h-5 mt-1 text-muted-foreground" />
               <div>
-                <Label className="text-muted-foreground">End</Label>
+                <Label className="text-muted-foreground">Sluttid</Label>
                 <div className="flex items-center gap-4">
                   {values.endDate && (
                     <div className="flex items-center gap-1">
@@ -174,7 +174,7 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
             <div className="flex items-start gap-3">
               <CalendarIcon className="w-5 h-5 mt-1 text-muted-foreground" />
               <div>
-                <Label className="text-muted-foreground">Dates</Label>
+                <Label className="text-muted-foreground">Datum</Label>
                 <div className="space-y-1 mt-1">
                   {values.singleDates.map((sd, i) => (
                     <div key={i} className="flex items-center gap-2 text-sm">
@@ -201,10 +201,10 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
             <div className="flex items-start gap-3">
               <CalendarIcon className="w-5 h-5 mt-1 text-muted-foreground" />
               <div>
-                <Label className="text-muted-foreground">Weekdays</Label>
+                <Label className="text-muted-foreground">Veckodagar</Label>
                 <p>
                   {values.weekdays
-                    .map((d) => d.charAt(0).toUpperCase() + d.slice(1))
+                    .map((d) => ({ mon:"Måndag",tue:"Tisdag",wed:"Onsdag",thu:"Torsdag",fri:"Fredag",sat:"Lördag",sun:"Söndag" }[d] ?? d))
                     .join(", ")}
                 </p>
                 {(values.scheduleStartTime || values.scheduleEndTime) && (
@@ -223,8 +223,8 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
               <Label className="text-muted-foreground">Spotlight</Label>
               <p className="mt-0.5">
                 {values.spotlight
-                  ? `Enabled — ${fmt(values.spotlightStartDate)} → ${fmt(values.spotlightEndDate)}`
-                  : "Disabled"}
+                  ? `Aktiverad — ${fmt(values.spotlightStartDate)} → ${fmt(values.spotlightEndDate)}`
+                  : "Inaktiverad"}
               </p>
        {/*  this cost box is under Spotlight-text */}
               {isSpotlight && s && e && days > 0 && (
@@ -238,22 +238,22 @@ export function StepReviewEvent({ values }: StepReviewEventProps) {
 
                   <div className="text-sm">
                     <div className="flex justify-between">
-                      <span>{days} days × 99 kr</span>
+                      <span>{days} dagar × 99 kr</span>
                       <span className="font-medium">{money.format(subtotal)}</span>
                     </div>
                     <div className="flex justify-between mt-1">
-                      <span>VAT (included)</span>
+                      <span>Moms (inkluderad)</span>
                       <span className="font-medium">{money.format(vat)}</span>
                     </div>
                     <hr className="my-2" />
                     <div className="flex justify-between text-base">
-                      <span className="font-semibold">Total (incl. VAT)</span>
+                      <span className="font-semibold">Totalt (inkl. moms)</span>
                       <span className="font-semibold">{money.format(total)}</span>
                     </div>
                   </div>
 
                   <p className="text-xs text-muted-foreground mt-2">
-                    The price is 99 kr per day plus 125 kr VAT. VAT is included in the total
+                    Priset är 99 kr per dag plus 125 kr moms. Momsen ingår i totalpriset.
                   </p>
                 </div>
               )}

--- a/src/components/forms/steps/StepSpotlight.tsx
+++ b/src/components/forms/steps/StepSpotlight.tsx
@@ -88,7 +88,7 @@ export function StepSpotlight() {
         <div>
           <Label className="font-medium">Spotlight</Label>
           <p className="text-sm text-muted-foreground">
-            Promote this event in spotlight. Toggle off to skip spotlight settings.
+            Lyft fram ditt evenemang i spotlight. Stäng av för att hoppa över spotlightinställningarna.
           </p>
         </div>
         <input
@@ -110,7 +110,7 @@ export function StepSpotlight() {
             name="spotlightStartDate"
             render={({ field, fieldState }) => (
               <div>
-                <Label className="block mb-1">Spotlight start date</Label>
+                <Label className="block mb-1">Startdatum för spotlight</Label>
                 <Popover>
                   <PopoverTrigger asChild>
                     <Button
@@ -121,7 +121,7 @@ export function StepSpotlight() {
                       )}
                     >
                       <CalendarIcon className="mr-2 h-4 w-4" />
-                      {field.value ? format(field.value, "dd.MM.yyyy") : "Pick a date"}
+                      {field.value ? format(field.value, "dd.MM.yyyy") : "Välj datum"}
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent className="w-auto p-0" align="start">
@@ -147,7 +147,7 @@ export function StepSpotlight() {
             name="spotlightEndDate"
             render={({ field, fieldState }) => (
               <div>
-                <Label className="block mb-1">Spotlight end date</Label>
+                <Label className="block mb-1">Slutdatum för spotlight</Label>
                 <Popover>
                   <PopoverTrigger asChild>
                     <Button
@@ -159,7 +159,7 @@ export function StepSpotlight() {
                       disabled={!spotlight}
                     >
                       <CalendarIcon className="mr-2 h-4 w-4" />
-                      {field.value ? format(field.value, "dd.MM.yyyy") : "Pick a date"}
+                      {field.value ? format(field.value, "dd.MM.yyyy") : "Välj datum"}
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent className="w-auto p-0" align="start">
@@ -184,7 +184,7 @@ export function StepSpotlight() {
       {/* Image upload */}
       {spotlight && (
         <div className="space-y-2">
-          <Label>Banner image (optional)</Label>
+          <Label>Bannerbild (valfritt)</Label>
 
           {spotlightImageUrl ? (
             <div className="relative">
@@ -204,7 +204,7 @@ export function StepSpotlight() {
                 onClick={handleRemove}
               >
                 <X className="mr-1 h-3 w-3" />
-                Remove / Replace
+                Ta bort / Ersätt
               </Button>
             </div>
           ) : (
@@ -231,7 +231,7 @@ export function StepSpotlight() {
               {isUploading ? (
                 <div className="flex flex-col items-center gap-2">
                   <div className="h-6 w-6 animate-spin rounded-full border-2 border-yellow-400 border-t-transparent" />
-                  <span className="text-sm text-muted-foreground">Uploading…</span>
+                  <span className="text-sm text-muted-foreground">Laddar upp…</span>
                 </div>
               ) : (
                 <>
@@ -243,9 +243,9 @@ export function StepSpotlight() {
                     )}
                   </div>
                   <p className="text-sm font-medium">
-                    Drag & drop or click to upload
+                    Dra och släpp eller klicka för att ladda upp
                   </p>
-                  <p className="text-xs text-muted-foreground">JPEG, PNG or WebP · max 5 MB</p>
+                  <p className="text-xs text-muted-foreground">JPEG, PNG eller WebP · max 5 MB</p>
                 </>
               )}
             </div>
@@ -261,7 +261,7 @@ export function StepSpotlight() {
 {spotlight && startDate && endDate && (
   <>
     <p className="text-sm text-muted-foreground">
-      Spotlight period:{" "}
+      Spotlightperiod:{" "}
       <span className="font-medium">{format(startDate, "dd.MM.yyyy")}</span>{" "}
       {"\u2192"}{" "}
       <span className="font-medium">{format(endDate, "dd.MM.yyyy")}</span>
@@ -270,21 +270,21 @@ export function StepSpotlight() {
     <div className="rounded-2xl border p-4 bg-muted/30">
       <div className="text-sm">
         <div className="flex justify-between">
-          <span>{days} days × 99 kr</span>
+          <span>{days} dagar × 99 kr</span>
           <span className="font-medium">{fmt.format(subtotal)}</span>
         </div>
         <div className="flex justify-between mt-1">
-          <span>VAT (included)</span>
+          <span>Moms (inkluderad)</span>
           <span className="font-medium">{fmt.format(vat)}</span>
         </div>
         <hr className="my-2" />
         <div className="flex justify-between text-base">
-          <span className="font-semibold">Total (incl. VAT)</span>
+          <span className="font-semibold">Totalt (inkl. moms)</span>
           <span className="font-semibold">{fmt.format(total)}</span>
         </div>
       </div>
       <p className="text-xs text-muted-foreground mt-2">
-        The price is 99 SEK per day plus 125 SEK VAT. VAT is included in the total
+        Priset är 99 kr per dag plus 125 kr moms. Momsen ingår i totalpriset.
       </p>
     </div>
   </>

--- a/src/components/global/Navbar.tsx
+++ b/src/components/global/Navbar.tsx
@@ -49,7 +49,7 @@ export function Navbar() {
             {showSearch ? (
               <div className="flex items-center gap-2 border rounded-md px-2 py-1 bg-white shadow-sm">
                 <Input
-                  placeholder="Search..."
+                  placeholder="Sök..."
                   className="w-48 border-none focus-visible:ring-0 focus-visible:ring-offset-0"
                   onBlur={() => setShowSearch(false)}
                   autoFocus
@@ -66,12 +66,12 @@ export function Navbar() {
             {/* profile + logout buttons — only when logged in */}
             {isLoggedIn && (
               <Button variant="outline" size="sm" onClick={() => router.push("/profile")}>
-                Profile
+                Profil
               </Button>
             )}
             {isLoggedIn && (
               <Button variant="outline" size="sm" onClick={onLogout}>
-                Log out
+                Logga ut
               </Button>
             )}
           </div>

--- a/src/lib/content/strings-en.ts
+++ b/src/lib/content/strings-en.ts
@@ -1,0 +1,131 @@
+/**
+ * English string archive — kept for reference if the app ever needs multi-language support.
+ * These are the original English UI strings before the Swedish translation (ticket #87).
+ * NOT used at runtime.
+ */
+
+export const EN = {
+  // EventFormStepper
+  stepper: {
+    back: "Back",
+    next: "Next",
+    submit: "Submit",
+    requiredFieldsTooltip: "Please fill out all required fields before continuing.",
+  },
+
+  // StepEventDetails
+  details: {
+    organiserLabel: "Organiser",
+    organiserPlaceholder: "Organiser name",
+    orgNrLabel: "Organisation number",
+    orgNrPlaceholder: "XXXXXX-XXXX",
+    orgNrAutoFilled: "Auto-filled from your account",
+    titleLabel: "Title",
+    titlePlaceholder: "Event Title",
+    categoriesLabel: "Select Categories",
+    categoriesHelp: "Max {MAX_CATEGORIES} categories — click a selected category to open subcategories",
+    subcategoriesSuffix: "Subcategories",
+    unselectAll: "Unselect All",
+    selectAll: "Select All",
+    filtersLabel: "Filters",
+    descriptionLabel: "Description",
+    descriptionPlaceholder: "Event Description",
+    eventUrlLabel: "Event URL",
+    eventUrlPlaceholder: "https://event-link.com",
+    bookingUrlLabel: "Booking URL",
+    bookingUrlPlaceholder: "https://booking-link.com",
+    notAllRequired: "* Not all fields above are required",
+  },
+
+  // StepEventLocation
+  location: {
+    streetNameLabel: "Street Name",
+    streetNamePlaceholder: "Street name",
+    streetName2Label: "Street Name 2",
+    streetName2Placeholder: "Apartment, suite, etc.",
+    houseNumberLabel: "House Number",
+    houseNumberPlaceholder: "123",
+    cityLabel: "City",
+    cityPlaceholder: "City name",
+    postalCodeLabel: "Postal Code",
+    postalCodePlaceholder: "12345",
+    gpsLabel: "GPS Coordinates",
+    gpsAriaLabel: "Show GPS help",
+    gpsPlaceholder: "e.g., 56.0465, 12.6945",
+    notAllRequired: "* Not all fields above are required",
+  },
+
+  // StepEventDateTime
+  datetime: {
+    timingTypeLabel: "Select Timing Type",
+    singleInstance: "Single instance",
+    multipleDates: "Multiple dates",
+    recurringWeekly: "Recurring (weekly)",
+    alwaysOpen: "Always Open",
+    selectDate: "Select date",
+    selectDateRange: "Select date range",
+    startTimeLabel: "Start Time",
+    startTimePlaceholder: "Start",
+    endTimeLabel: "End Time",
+    endTimePlaceholder: "End",
+    weekdayShort: { mon: "Mon", tue: "Tue", wed: "Wed", thu: "Thu", fri: "Fri", sat: "Sat", sun: "Sun" },
+    alwaysOpenDescription: "This event will be listed as always open.",
+    notAllRequired: "* Not all fields above are required",
+  },
+
+  // StepSpotlight
+  spotlight: {
+    label: "Spotlight",
+    description: "Promote this event in spotlight. Toggle off to skip spotlight settings.",
+    startDateLabel: "Spotlight start date",
+    endDateLabel: "Spotlight end date",
+    pickDate: "Pick a date",
+    period: "Spotlight period:",
+    daysPrice: "{days} days × 99 kr",
+    vat: "VAT (included)",
+    total: "Total (incl. VAT)",
+    priceNote: "The price is 99 SEK per day plus 125 SEK VAT. VAT is included in the total",
+  },
+
+  // StepEventReview
+  review: {
+    heading: "Review your event info",
+    eventTitle: "Event Title",
+    organiser: "Organiser",
+    orgNr: "Organisation number",
+    description: "Description",
+    location: "Location",
+    eventUrl: "Event URL",
+    bookingUrl: "Booking URL",
+    start: "Start",
+    end: "End",
+    dates: "Dates",
+    weekdays: "Weekdays",
+    spotlight: "Spotlight",
+    spotlightEnabled: "Enabled",
+    spotlightDisabled: "Disabled",
+    period: "Period:",
+    daysPrice: "{days} days × 99 kr",
+    vat: "VAT (included)",
+    total: "Total (incl. VAT)",
+    priceNote: "The price is 99 kr per day plus 125 kr VAT. VAT is included in the total",
+  },
+
+  // Zod validation messages (create-event-schema.ts)
+  validation: {
+    organiserRequired: "Organiser is required",
+    orgNrRequired: "Organisation number is required",
+    orgNrFormat: "Use format XXXXXX-XXXX",
+    orgNrInvalid: "Invalid organisation number (checksum)",
+    titleRequired: "Title is required",
+    descriptionRequired: "Description is required",
+    categoryRequired: "Please select at least one category",
+    invalidUrl: "Must be a valid URL",
+    streetNameRequired: "Street name is required",
+    cityRequired: "City is required",
+    postalCodeRequired: "Postal code is required",
+    maxChars: "Max 50 characters",
+    startTimeRequired: "Start time is required",
+    endTimeRequired: "End time is required",
+  },
+} as const;

--- a/src/lib/validation/create-event-schema.ts
+++ b/src/lib/validation/create-event-schema.ts
@@ -276,7 +276,7 @@ export const eventDtoToFormData = (event: {
     bookingUrl: event.bookingUrl || "",
 
     streetName: event.streetName || "",
-    houseNumber: event.houseNumber || 0,
+    houseNumber: event.houseNumber ?? undefined,
 
     city: event.city || "",
     postalCode: event.postalCode || "",

--- a/src/lib/validation/create-event-schema.ts
+++ b/src/lib/validation/create-event-schema.ts
@@ -3,29 +3,28 @@ import { z } from "zod";
 import { ORGNR_REGEX, isValidSwedishOrgNr } from "@/lib/utils";
 
 export const createEventSchema = z.object({
-  organiser: z.string().min(1, "Organiser is required"),
+  organiser: z.string().min(1, "Arrangör krävs"),
   organisationNumber: z
     .string()
-    .min(1, "Organisation number is required")
-    .regex(ORGNR_REGEX, "Use format XXXXXX-XXXX")
-    .refine(isValidSwedishOrgNr, "Invalid organisation number (checksum)"),
-  title: z.string().min(1, "Title is required"),
-  description: z.string().min(1, "Description is required"),
-  categories: z.array(z.number()).min(1, "Please select at least one category"),
+    .min(1, "Organisationsnummer krävs")
+    .regex(ORGNR_REGEX, "Använd formatet XXXXXX-XXXX")
+    .refine(isValidSwedishOrgNr, "Ogiltigt organisationsnummer (kontrollsumma)"),
+  title: z.string().min(1, "Titel krävs"),
+  description: z.string().min(1, "Beskrivning krävs"),
+  categories: z.array(z.number()).min(1, "Välj minst en kategori"),
   subcategories: z.record(z.number(), z.array(z.number())).optional(),
-  filters: z.array(z.number()).min(1, "Please select at least one category").optional(),
+  filters: z.array(z.number()).min(1, "Välj minst ett filter").optional(),
 
-  eventUrl: z.url("Must be a valid URL").optional().or(z.literal("")),
+  eventUrl: z.url("Måste vara en giltig URL").optional().or(z.literal("")),
 
-  bookingUrl: z.url("Must be a valid URL").optional().or(z.literal("")),
+  bookingUrl: z.url("Måste vara en giltig URL").optional().or(z.literal("")),
 
-  streetName: z.string().min(1, "Street name is required"),
-  streetName2: z.string().optional(),
-  houseNumber: z.number().int("Must be a number").positive("Must be greater than 0").optional(),
+  streetName: z.string().min(1, "Gatunamn krävs"),
+  houseNumber: z.number().int("Måste vara ett heltal").positive("Måste vara större än 0").optional(),
 
-  city: z.string().min(1, "City is required"),
-  postalCode: z.string().min(1, "Postal code is required"),
-  gpsCoordinates: z.string().max(50, "Max 50 characters").optional().or(z.literal("")),
+  city: z.string().min(1, "Stad krävs"),
+  postalCode: z.string().min(1, "Postnummer krävs"),
+  gpsCoordinates: z.string().max(50, "Max 50 tecken").optional().or(z.literal("")),
 
   hasSingleDates: z.boolean().optional(),
   startDate: z.date().optional(),
@@ -60,14 +59,14 @@ export const createEventSchema = z.object({
 }).superRefine((data, ctx) => {
   if (data.hasSingleDates) {
     if (!data.startTime) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Start time is required", path: ["startTime"] });
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Starttid krävs", path: ["startTime"] });
     }
     if (!data.endTime) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "End time is required", path: ["endTime"] });
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Sluttid krävs", path: ["endTime"] });
     }
   }
   if (data.hasMultipleDates && (!data.singleDates || data.singleDates.length === 0)) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Add at least one date", path: ["singleDates"] });
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Lägg till minst ett datum", path: ["singleDates"] });
   }
 });
 
@@ -84,8 +83,7 @@ export const defaultFormValues: CreateEventFormData = {
   bookingUrl: "",
 
   streetName: "",
-  streetName2: "",
-  houseNumber: 0,
+  houseNumber: undefined,
 
   city: "",
   postalCode: "",
@@ -167,7 +165,6 @@ export const createPayload = (data: CreateEventFormData): CreateEventDto => {
     bookingUrl: data.bookingUrl || undefined,
 
     streetName: data.streetName,
-    streetName2: data.streetName2 || undefined,
     houseNumber: data.houseNumber,
 
     city: data.city,
@@ -218,7 +215,6 @@ export const eventDtoToFormData = (event: {
   eventUrl?: string;
   bookingUrl?: string;
   streetName: string;
-  streetName2?: string;
   houseNumber?: number;
   city: string;
   postalCode: string;
@@ -280,7 +276,6 @@ export const eventDtoToFormData = (event: {
     bookingUrl: event.bookingUrl || "",
 
     streetName: event.streetName || "",
-    streetName2: event.streetName2 || "",
     houseNumber: event.houseNumber || 0,
 
     city: event.city || "",


### PR DESCRIPTION
## Summary

- Translate all UI strings to Swedish across every page and form step (create-event, edit, my-events, landing, navbar, profile, quick-create, login, register, forgot/reset-password)
- Remove `streetName2` field from form schema, default values, `createPayload()`, and `eventDtoToFormData()` — kept in `EventDto` for backend compatibility
- Remove "not all fields required" notice from all form steps
- Archive original English strings in `src/lib/content/strings-en.ts` for future reference

## Fixes applied (code review)

- Fix `TimePicker` to store `HH:mm` in form state (was `HH:mm:ss`)
- Fix `TimePicker` to display 24-hour time (was showing Swedish AM/PM locale)
- Fix `houseNumber` default value from `0` to `undefined` (was failing `.positive()` validation)
- Fix `filters` Zod error message to "Välj minst ett filter"
- Remove debug `console.log` calls from `create-event` and edit pages

## Test plan

- [ ] Create a new event — all steps display in Swedish
- [ ] Edit an existing event — all labels, toasts, and buttons in Swedish
- [ ] TimePicker shows and stores 24-hour format (e.g. `14:30`, not `2:30 em`)
- [ ] `houseNumber` field: leaving it empty doesn't trigger validation error on blur
- [ ] Filters: submitting without a filter shows "Välj minst ett filter"
- [ ] My Events page — all text in Swedish
- [ ] Login / Register / Forgot password / Reset password — all in Swedish
- [ ] Profile page — all text in Swedish
- [ ] Quick-create page (admin) — all text in Swedish

🤖 Generated with [Claude Code](https://claude.com/claude-code)