### PR TITLE
feat(spotlight): mocked spotlight placement purchase UI

### DIFF
--- a/.claude/current-work.md
+++ b/.claude/current-work.md
@@ -3,9 +3,39 @@
 > **This file is read at the start of every Claude Code session and updated on every commit/push.**
 > It provides continuity between sessions.
 
-Last updated: 2026-06-12
+Last updated: 2026-06-30
 
 ## Active Task
+**Spotlight placement purchase UI** — branch `feature/spotlight-payments-ui` (committed locally, not pushed).
+
+### What was done (2026-06-30):
+
+**Branch: `feature/spotlight-payments-ui`**
+
+New organiser-facing flow to buy a Spotlight placement for an event. Consumes the new
+Backend `/api/spotlight` API. Payments are MOCKED end-to-end (no real Stripe/Klarna/Swish SDK).
+
+- `src/types/spotlight.ts` — types for SpotlightPackage, checkout/confirm requests + responses, SpotlightPayment.
+- `src/types/events.ts` — added optional `isForbidden` / `isNotFound` to `OperationResult<T>` (matches BE contract).
+- `src/hooks/useSpotlight.ts` — TanStack Query hooks: packages, payments, checkout, confirm.
+- `src/components/spotlight/SpotlightPurchaseDialog.tsx` — 5-step state machine modal
+  (package → method → processing → success → error). Checkout then immediate confirm
+  (mock gateway auto-approves). Honest "Demo / testläge" badge on payment step.
+- `src/app/my-events/page.tsx` — "Spotlight" button on each event card (entry point) +
+  "Spotlight" badge when an event's spotlight window is active.
+- `src/lib/content/strings-en.ts` — EN archive strings for the new flow.
+
+### Decisions made
+- Entry point = button on the my-events event card (best match for existing UX).
+- Runtime copy is Swedish inline (matches the rest of the app post-#87); EN kept in the archive file.
+- Providers shown: Stripe / Klarna / Swish (the real options to wire later); selected provider
+  is sent to `/checkout`, which the mock gateway auto-approves via the immediate `/confirm` call.
+
+### What's next:
+1. Push branch + open PR when ready.
+2. Wire real payment SDKs later (replace the immediate confirm with provider redirect/webhook return).
+
+## Earlier Task
 **Translate frontend to Swedish — Issue #87** — PR #89 open, issue moved to "In Review".
 
 ### What was done (2026-06-12):

--- a/src/app/my-events/page.tsx
+++ b/src/app/my-events/page.tsx
@@ -13,6 +13,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Loader2,
+  Sparkles,
 } from "lucide-react";
 
 import { Navbar } from "@/components/global/Navbar";
@@ -28,8 +29,15 @@ import {
 } from "@/components/ui/dialog";
 
 import { useEvents, useDeleteEvent } from "@/hooks/useEvents";
+import { SpotlightPurchaseDialog } from "@/components/spotlight/SpotlightPurchaseDialog";
 import type { EventDto } from "@/types/events";
 import { getStoredJwtPayload, getUserIdFromPayload } from "@/lib/jwt";
+
+// An event is "in the spotlight" when it's flagged and the spotlight window hasn't ended.
+function isSpotlightActive(event: EventDto): boolean {
+  if (!event.spotlight || !event.spotlightEndDate) return false;
+  return new Date(event.spotlightEndDate) >= new Date();
+}
 
 function getUserIdFromToken(): string | null {
   const payload = getStoredJwtPayload();
@@ -56,6 +64,9 @@ export default function MyEventsPage() {
 
   // Delete state
   const [deletingEvent, setDeletingEvent] = useState<EventDto | null>(null);
+
+  // Spotlight purchase state
+  const [spotlightEvent, setSpotlightEvent] = useState<EventDto | null>(null);
 
   const events = data?.data?.items || [];
   const totalCount = data?.data?.totalCount || 0;
@@ -156,10 +167,27 @@ export default function MyEventsPage() {
                   <CardHeader className="pb-2">
                     <div className="flex justify-between items-start">
                       <div>
-                        <CardTitle className="text-xl">{event.title}</CardTitle>
+                        <div className="flex items-center gap-2">
+                          <CardTitle className="text-xl">{event.title}</CardTitle>
+                          {isSpotlightActive(event) && (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-[#F3C10E]/20 px-2 py-0.5 text-xs font-medium text-yellow-800">
+                              <Sparkles className="w-3 h-3" />
+                              Spotlight
+                            </span>
+                          )}
+                        </div>
                         <p className="text-sm text-gray-500 mt-1">{event.organiser}</p>
                       </div>
                       <div className="flex gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="gap-1.5 text-yellow-700 hover:text-yellow-800 hover:bg-[#F3C10E]/10"
+                          onClick={() => setSpotlightEvent(event)}
+                        >
+                          <Sparkles className="w-4 h-4" />
+                          <span className="hidden sm:inline">Spotlight</span>
+                        </Button>
                         <Button variant="outline" size="sm" onClick={() => handleEditClick(event)}>
                           <Pencil className="w-4 h-4" />
                         </Button>
@@ -279,6 +307,18 @@ export default function MyEventsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Spotlight Purchase Dialog */}
+      {spotlightEvent && (
+        <SpotlightPurchaseDialog
+          open={!!spotlightEvent}
+          onOpenChange={(open) => {
+            if (!open) setSpotlightEvent(null);
+          }}
+          eventId={spotlightEvent.id}
+          eventTitle={spotlightEvent.title}
+        />
+      )}
     </main>
   );
 }

--- a/src/components/spotlight/SpotlightPurchaseDialog.tsx
+++ b/src/components/spotlight/SpotlightPurchaseDialog.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import * as React from "react";
+import { toast } from "sonner";
+import { Sparkles, Loader2, Check, CreditCard, AlertCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import {
+  useSpotlightPackages,
+  useSpotlightCheckout,
+  useSpotlightConfirm,
+} from "@/hooks/useSpotlight";
+import type { SpotlightPackage, SpotlightProvider } from "@/types/spotlight";
+
+type Step = "package" | "method" | "processing" | "success" | "error";
+
+// The real providers we'll wire later. Payments are simulated for now (mock gateway).
+const PROVIDERS: { id: SpotlightProvider; label: string }[] = [
+  { id: "stripe", label: "Stripe" },
+  { id: "klarna", label: "Klarna" },
+  { id: "swish", label: "Swish" },
+];
+
+const sek = (amount: number, currency: string) =>
+  new Intl.NumberFormat("sv-SE", {
+    style: "currency",
+    currency: currency || "SEK",
+    maximumFractionDigits: 0,
+  }).format(amount);
+
+const formatDate = (dateStr?: string | null) => {
+  if (!dateStr) return "-";
+  return new Date(dateStr).toLocaleDateString("sv-SE");
+};
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  eventId: string;
+  eventTitle: string;
+};
+
+export function SpotlightPurchaseDialog({ open, onOpenChange, eventId, eventTitle }: Props) {
+  const [step, setStep] = React.useState<Step>("package");
+  const [selectedPackage, setSelectedPackage] = React.useState<SpotlightPackage | null>(null);
+  const [provider, setProvider] = React.useState<SpotlightProvider>("stripe");
+  const [endDate, setEndDate] = React.useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = React.useState<string>("");
+
+  const { data: packagesResult, isLoading: isLoadingPackages } = useSpotlightPackages();
+  const checkout = useSpotlightCheckout();
+  const confirm = useSpotlightConfirm();
+
+  const packages = packagesResult?.data ?? [];
+
+  // Reset internal state whenever the dialog is (re)opened.
+  React.useEffect(() => {
+    if (open) {
+      setStep("package");
+      setSelectedPackage(null);
+      setProvider("stripe");
+      setEndDate(null);
+      setErrorMessage("");
+    }
+  }, [open]);
+
+  const handlePurchase = async () => {
+    if (!selectedPackage) return;
+    setStep("processing");
+    setErrorMessage("");
+
+    try {
+      // 1) Start checkout (owner-only).
+      const checkoutResult = await checkout.mutateAsync({
+        eventId,
+        packageCode: selectedPackage.code,
+        provider,
+      });
+
+      if (!checkoutResult.isSuccess) {
+        setErrorMessage(
+          checkoutResult.isForbidden
+            ? "Du kan bara lyfta fram evenemang som du själv äger."
+            : checkoutResult.errors?.[0] || "Det gick inte att starta betalningen."
+        );
+        setStep("error");
+        return;
+      }
+
+      // 2) Immediately confirm — the mock gateway auto-approves (stands in for the
+      //    provider webhook/redirect-return). On success the spotlight goes live.
+      const confirmResult = await confirm.mutateAsync({
+        paymentId: checkoutResult.data.paymentId,
+      });
+
+      if (!confirmResult.isSuccess) {
+        setErrorMessage(confirmResult.errors?.[0] || "Det gick inte att bekräfta betalningen.");
+        setStep("error");
+        return;
+      }
+
+      setEndDate(confirmResult.data.spotlightEndDate);
+      setStep("success");
+      toast.success("Ditt evenemang är nu i spotlight");
+    } catch (err: unknown) {
+      // Axios throws on 4xx (e.g. 403 for non-owners).
+      const status =
+        typeof err === "object" && err !== null && "response" in err
+          ? (err as { response?: { status?: number } }).response?.status
+          : undefined;
+      setErrorMessage(
+        status === 403
+          ? "Du kan bara lyfta fram evenemang som du själv äger."
+          : "Något gick fel. Försök igen senare."
+      );
+      setStep("error");
+    }
+  };
+
+  const isProcessing = step === "processing";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-[#F3C10E]" />
+            Lyft fram evenemang
+          </DialogTitle>
+          <DialogDescription>{eventTitle}</DialogDescription>
+        </DialogHeader>
+
+        {/* STEP 1 — choose a package */}
+        {step === "package" && (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Välj hur länge ditt evenemang ska visas i spotlight.
+            </p>
+
+            {isLoadingPackages && (
+              <div className="flex justify-center py-8">
+                <Loader2 className="h-6 w-6 animate-spin" />
+              </div>
+            )}
+
+            {!isLoadingPackages && packages.length === 0 && (
+              <p className="text-sm text-destructive">
+                Det gick inte att hämta paket. Försök igen.
+              </p>
+            )}
+
+            <div className="space-y-2">
+              {packages.map((pkg) => {
+                const active = selectedPackage?.code === pkg.code;
+                return (
+                  <button
+                    key={pkg.code}
+                    type="button"
+                    onClick={() => setSelectedPackage(pkg)}
+                    className={cn(
+                      "flex w-full items-center justify-between rounded-xl border p-4 text-left transition-colors",
+                      active
+                        ? "border-[#F3C10E] bg-[#F3C10E]/10 ring-1 ring-[#F3C10E]"
+                        : "hover:border-[#F3C10E]/60"
+                    )}
+                  >
+                    <div>
+                      <p className="font-medium">{pkg.name}</p>
+                      <p className="text-sm text-muted-foreground">{pkg.durationDays} dagar</p>
+                    </div>
+                    <span className="text-base font-semibold">
+                      {sek(pkg.amount, pkg.currency)}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <Button
+              className="w-full"
+              disabled={!selectedPackage}
+              onClick={() => setStep("method")}
+            >
+              Fortsätt
+            </Button>
+          </div>
+        )}
+
+        {/* STEP 2 — choose a payment method */}
+        {step === "method" && selectedPackage && (
+          <div className="space-y-4">
+            <div className="rounded-xl border bg-muted/30 p-3 text-sm">
+              <div className="flex justify-between">
+                <span>{selectedPackage.name}</span>
+                <span className="font-medium">
+                  {sek(selectedPackage.amount, selectedPackage.currency)}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {selectedPackage.durationDays} dagar i spotlight
+              </p>
+            </div>
+
+            <div>
+              <p className="mb-2 text-sm font-medium">Välj betalsätt</p>
+              <div className="grid grid-cols-3 gap-2">
+                {PROVIDERS.map((p) => {
+                  const active = provider === p.id;
+                  return (
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => setProvider(p.id)}
+                      className={cn(
+                        "flex h-16 flex-col items-center justify-center gap-1 rounded-xl border text-sm font-medium transition-colors",
+                        active
+                          ? "border-[#F3C10E] bg-[#F3C10E]/10 ring-1 ring-[#F3C10E]"
+                          : "hover:border-[#F3C10E]/60"
+                      )}
+                    >
+                      <CreditCard className="h-4 w-4 text-muted-foreground" />
+                      {p.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Honest note: payments are simulated for now. */}
+            <div className="flex items-start gap-2 rounded-lg bg-amber-50 p-3 text-xs text-amber-800">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                <span className="font-semibold">Demo / testläge.</span> Betalningar simuleras just
+                nu — inga riktiga pengar dras. Riktig betalning kopplas på senare.
+              </span>
+            </div>
+
+            <div className="flex gap-2">
+              <Button variant="outline" className="flex-1" onClick={() => setStep("package")}>
+                Tillbaka
+              </Button>
+              <Button className="flex-1" onClick={handlePurchase}>
+                Betala {sek(selectedPackage.amount, selectedPackage.currency)}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* STEP 3 — processing */}
+        {isProcessing && (
+          <div className="flex flex-col items-center gap-3 py-10">
+            <Loader2 className="h-8 w-8 animate-spin text-[#F3C10E]" />
+            <p className="text-sm text-muted-foreground">Behandlar betalningen…</p>
+          </div>
+        )}
+
+        {/* STEP 4 — success */}
+        {step === "success" && (
+          <div className="flex flex-col items-center gap-3 py-6 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+              <Check className="h-6 w-6 text-green-600" />
+            </div>
+            <p className="font-medium">Betalningen lyckades</p>
+            <p className="text-sm text-muted-foreground">
+              Ditt evenemang är nu i spotlight till och med{" "}
+              <span className="font-medium text-foreground">{formatDate(endDate)}</span>.
+            </p>
+            <Button className="mt-2 w-full" onClick={() => onOpenChange(false)}>
+              Klar
+            </Button>
+          </div>
+        )}
+
+        {/* STEP 5 — error */}
+        {step === "error" && (
+          <div className="flex flex-col items-center gap-3 py-6 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+              <AlertCircle className="h-6 w-6 text-red-600" />
+            </div>
+            <p className="font-medium">Något gick fel</p>
+            <p className="text-sm text-muted-foreground">{errorMessage}</p>
+            <div className="mt-2 flex w-full gap-2">
+              <Button variant="outline" className="flex-1" onClick={() => onOpenChange(false)}>
+                Stäng
+              </Button>
+              <Button className="flex-1" onClick={() => setStep("package")}>
+                Försök igen
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/useSpotlight.ts
+++ b/src/hooks/useSpotlight.ts
@@ -1,0 +1,70 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/axios";
+import { OperationResult } from "@/types/events";
+import {
+  SpotlightPackage,
+  SpotlightCheckoutRequest,
+  SpotlightCheckoutResponse,
+  SpotlightConfirmRequest,
+  SpotlightPayment,
+} from "@/types/spotlight";
+
+// GET /api/spotlight/packages — public catalogue (no auth required)
+export function useSpotlightPackages() {
+  return useQuery({
+    queryKey: ["spotlight-packages"],
+    queryFn: async () => {
+      const response =
+        await api.get<OperationResult<SpotlightPackage[]>>("/spotlight/packages");
+      return response.data;
+    },
+    staleTime: 1000 * 60 * 10, // catalogue rarely changes
+  });
+}
+
+// GET /api/spotlight/payments — caller's purchase history
+export function useSpotlightPayments(enabled = true) {
+  return useQuery({
+    queryKey: ["spotlight-payments"],
+    queryFn: async () => {
+      const response =
+        await api.get<OperationResult<SpotlightPayment[]>>("/spotlight/payments");
+      return response.data;
+    },
+    enabled,
+  });
+}
+
+// POST /api/spotlight/checkout — start a payment (owner only)
+export function useSpotlightCheckout() {
+  return useMutation({
+    mutationFn: async (body: SpotlightCheckoutRequest) => {
+      const response = await api.post<OperationResult<SpotlightCheckoutResponse>>(
+        "/spotlight/checkout",
+        body
+      );
+      return response.data;
+    },
+  });
+}
+
+// POST /api/spotlight/confirm — mock stand-in for the provider webhook/redirect.
+// On success the event's spotlight goes live.
+export function useSpotlightConfirm() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (body: SpotlightConfirmRequest) => {
+      const response = await api.post<OperationResult<SpotlightPayment>>(
+        "/spotlight/confirm",
+        body
+      );
+      return response.data;
+    },
+    onSuccess: () => {
+      // Event spotlight state changed — refresh events + payment history.
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+      queryClient.invalidateQueries({ queryKey: ["spotlight-payments"] });
+    },
+  });
+}

--- a/src/lib/content/strings-en.ts
+++ b/src/lib/content/strings-en.ts
@@ -87,6 +87,35 @@ export const EN = {
     priceNote: "The price is 99 SEK per day plus 125 SEK VAT. VAT is included in the total",
   },
 
+  // SpotlightPurchaseDialog (my-events spotlight placement purchase flow)
+  spotlightPurchase: {
+    title: "Spotlight your event",
+    choosePackagePrompt: "Choose how long your event stays in the spotlight.",
+    packagesError: "Could not load packages. Please try again.",
+    continue: "Continue",
+    days: "{days} days",
+    daysInSpotlight: "{days} days in the spotlight",
+    choosePaymentMethod: "Choose a payment method",
+    demoBadgeTitle: "Demo / test mode.",
+    demoBadgeBody:
+      "Payments are simulated for now — no real money is charged. Real payments will be wired up later.",
+    back: "Back",
+    pay: "Pay",
+    processing: "Processing payment…",
+    paymentSuccess: "Payment successful",
+    spotlightUntil: "Your event is now in the spotlight until {date}.",
+    done: "Done",
+    errorTitle: "Something went wrong",
+    forbidden: "You can only spotlight events that you own.",
+    checkoutFailed: "Could not start the payment.",
+    confirmFailed: "Could not confirm the payment.",
+    genericError: "Something went wrong. Please try again later.",
+    close: "Close",
+    retry: "Try again",
+    badge: "Spotlight",
+    toastSuccess: "Your event is now in the spotlight",
+  },
+
   // StepEventReview
   review: {
     heading: "Review your event info",

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -156,6 +156,8 @@ export type OperationResult<T> = {
   isSuccess: boolean;
   data: T;
   errors: string[];
+  isForbidden?: boolean;
+  isNotFound?: boolean;
 };
 
 // ---- Moderation / Event Reports ----

--- a/src/types/spotlight.ts
+++ b/src/types/spotlight.ts
@@ -1,0 +1,54 @@
+// Types for the Spotlight placement purchase flow.
+// Mirrors the Backend /api/spotlight contract (all responses wrapped in OperationResult<T>).
+
+// Payment providers shown in the UI. "mock" is the auto-approving gateway used
+// while real Stripe/Klarna/Swish integrations are pending.
+export type SpotlightProvider = "stripe" | "klarna" | "swish" | "mock";
+
+// GET /api/spotlight/packages
+export type SpotlightPackage = {
+  code: string; // e.g. "spotlight_7"
+  name: string;
+  durationDays: number;
+  amount: number;
+  currency: string; // e.g. "SEK"
+};
+
+// POST /api/spotlight/checkout — request body
+export type SpotlightCheckoutRequest = {
+  eventId: string; // guid
+  packageCode: string;
+  provider: SpotlightProvider;
+};
+
+// POST /api/spotlight/checkout — response data
+export type SpotlightCheckoutResponse = {
+  paymentId: string;
+  provider: string;
+  status: string;
+  amount: number;
+  currency: string;
+  checkoutUrl: string | null;
+  providerReference: string | null;
+};
+
+// POST /api/spotlight/confirm — request body
+export type SpotlightConfirmRequest = {
+  paymentId: string;
+};
+
+// SpotlightPayment — returned by /confirm and /payments
+export type SpotlightPayment = {
+  id: string;
+  eventId: string;
+  packageCode: string;
+  durationDays: number;
+  amount: number;
+  currency: string;
+  provider: string;
+  status: string;
+  spotlightStartDate: string;
+  spotlightEndDate: string;
+  createdAt: string;
+  completedAt: string | null;
+};


### PR DESCRIPTION
## What
Adds the organiser-facing UI to buy a **spotlight placement** for an event. Payments are **mocked end-to-end** — no real Stripe/Klarna/Swish SDK is integrated. Consumes the new Backend `/api/spotlight` contract (merged in Backend #221).

## Entry point
A yellow ✨ **Spotlight** button on each event card in `/my-events` (next to edit/delete). An active **Spotlight** badge shows on events whose spotlight window is still live.

## Flow (SpotlightPurchaseDialog)
1. Choose a package (fetched from `GET /api/spotlight/packages`): 1wk 199 / 2wk 349 / 1mo 599 SEK
2. Choose a method — **Stripe / Klarna / Swish** buttons, with an honest amber **"Demo / testläge"** badge
3. Submit → `POST /checkout` then immediately `POST /confirm` (the mock gateway auto-approves; in production this becomes provider redirect/webhook) → success state ("…i spotlight till och med <date>")
4. Forbidden/error cases handled via `OperationResult` flags and axios 403s

## Files
- `src/types/spotlight.ts` — types + `SpotlightProvider` union
- `src/hooks/useSpotlight.ts` — TanStack Query hooks (mirrors `useEvents`)
- `src/components/spotlight/SpotlightPurchaseDialog.tsx` — the flow (shadcn Dialog/Button)
- `src/app/my-events/page.tsx` — entry button + active badge
- `src/types/events.ts` — `OperationResult<T>` gains optional `isForbidden?`/`isNotFound?` (backward-compatible)
- `src/lib/content/strings-en.ts` — EN archive strings

## Verified
`npm run lint` ✓ · `tsc --noEmit` ✓ · `npm run build` ✓ (all routes generated)

## Depends on / notes
- Requires Backend `/api/spotlight` deployed (Backend #221, already merged to main).
- No real payment SDKs added — providers are selectable buttons only. Runtime copy is Swedish inline to match the app.