### PR TITLE
feat: wire spotlight purchase to real Stripe checkout

### DIFF
--- a/.claude/current-work.md
+++ b/.claude/current-work.md
@@ -3,37 +3,49 @@
 > **This file is read at the start of every Claude Code session and updated on every commit/push.**
 > It provides continuity between sessions.
 
-Last updated: 2026-06-30
+Last updated: 2026-07-07
 
 ## Active Task
-**Spotlight placement purchase UI** — branch `feature/spotlight-payments-ui` (committed locally, not pushed).
+**Spotlight Stripe Checkout (real payments)** — branch `feature/spotlight-stripe-checkout`, PR opened.
 
-### What was done (2026-06-30):
+### What was done (2026-07-07):
 
-**Branch: `feature/spotlight-payments-ui`**
+**Branch: `feature/spotlight-stripe-checkout`** (cherry-picked the mocked UI from
+`feature/spotlight-payments-ui`, then rewired it to the LIVE backend Stripe endpoint —
+the old mock branch is now superseded and can be deleted).
 
-New organiser-facing flow to buy a Spotlight placement for an event. Consumes the new
-Backend `/api/spotlight` API. Payments are MOCKED end-to-end (no real Stripe/Klarna/Swish SDK).
-
-- `src/types/spotlight.ts` — types for SpotlightPackage, checkout/confirm requests + responses, SpotlightPayment.
-- `src/types/events.ts` — added optional `isForbidden` / `isNotFound` to `OperationResult<T>` (matches BE contract).
-- `src/hooks/useSpotlight.ts` — TanStack Query hooks: packages, payments, checkout, confirm.
-- `src/components/spotlight/SpotlightPurchaseDialog.tsx` — 5-step state machine modal
-  (package → method → processing → success → error). Checkout then immediate confirm
-  (mock gateway auto-approves). Honest "Demo / testläge" badge on payment step.
-- `src/app/my-events/page.tsx` — "Spotlight" button on each event card (entry point) +
-  "Spotlight" badge when an event's spotlight window is active.
-- `src/lib/content/strings-en.ts` — EN archive strings for the new flow.
+- `src/lib/spotlight.ts` — NEW single source for pricing: `SPOTLIGHT_PRICE_PER_DAY_SEK = 99`
+  (PLACEHOLDER pending product-owner confirmation), min/max days (1–90), `formatSek`,
+  `isSpotlightActive` / `isSpotlightScheduled` helpers.
+- `src/types/spotlight.ts` — replaced mock packages/confirm types with the real contract:
+  `SpotlightCheckoutRequest { days, startDate? }` → `SpotlightCheckoutResponse { checkoutUrl, sessionId }`.
+- `src/hooks/useSpotlight.ts` — single `useSpotlightCheckout()` mutation:
+  `POST /api/events/{eventId}/spotlight/checkout` (owner JWT, retry disabled).
+- `src/components/spotlight/SpotlightPurchaseDialog.tsx` — kept the dialog UX/design
+  (yellow chips, step states) but new flow: day presets (7/14/30) + custom input (1–90) +
+  optional start-date picker (min today) + live `days × 99 kr` price → full-page redirect
+  to Stripe `checkoutUrl`. Shows active/scheduled spotlight banner. Errors from
+  `OperationResult.errors[]` + 403/404 messages.
+- `src/app/spotlight/success/page.tsx` — NEW public Stripe return page (`?session_id=`),
+  "activates within a minute" copy, CTA to /my-events.
+- `src/app/spotlight/cancel/page.tsx` — NEW public cancel page, nothing charged, retry CTA.
+- `src/app/my-events/page.tsx` — dialog now takes the whole `event`; `isSpotlightActive`
+  moved to lib.
+- `src/components/forms/steps/StepSpotlight.tsx` — price constant now imported from lib.
+- `src/lib/content/strings-en.ts` — EN archive updated for the new flow + both pages.
 
 ### Decisions made
-- Entry point = button on the my-events event card (best match for existing UX).
-- Runtime copy is Swedish inline (matches the rest of the app post-#87); EN kept in the archive file.
-- Providers shown: Stripe / Klarna / Swish (the real options to wire later); selected provider
-  is sent to `/checkout`, which the mock gateway auto-approves via the immediate `/confirm` call.
+- Replaced the mock wiring instead of building a parallel UI (kept the dialog design).
+- Success/cancel URLs are `/spotlight/success` + `/spotlight/cancel` — BAKED INTO BACKEND
+  CONFIG, do not rename.
+- 99 SEK/day is display-only; the authoritative price lives in the backend Stripe session.
+- Payment confirmation is webhook-driven; the success page makes no API calls (public).
 
 ### What's next:
-1. Push branch + open PR when ready.
-2. Wire real payment SDKs later (replace the immediate confirm with provider redirect/webhook return).
+1. Product owner to confirm 99 SEK/day price (update `src/lib/spotlight.ts` if changed).
+2. Delete superseded branch `feature/spotlight-payments-ui` after merge.
+3. StepSpotlight in create/edit form still writes spotlight fields directly (legacy free
+   path) — decide whether backend ignores them now that spotlight is paid.
 
 ## Earlier Task
 **Translate frontend to Swedish — Issue #87** — PR #89 open, issue moved to "In Review".

--- a/.claude/current-work.md
+++ b/.claude/current-work.md
@@ -3,9 +3,39 @@
 > **This file is read at the start of every Claude Code session and updated on every commit/push.**
 > It provides continuity between sessions.
 
-Last updated: 2026-06-12
+Last updated: 2026-06-30
 
 ## Active Task
+**Spotlight placement purchase UI** — branch `feature/spotlight-payments-ui` (committed locally, not pushed).
+
+### What was done (2026-06-30):
+
+**Branch: `feature/spotlight-payments-ui`**
+
+New organiser-facing flow to buy a Spotlight placement for an event. Consumes the new
+Backend `/api/spotlight` API. Payments are MOCKED end-to-end (no real Stripe/Klarna/Swish SDK).
+
+- `src/types/spotlight.ts` — types for SpotlightPackage, checkout/confirm requests + responses, SpotlightPayment.
+- `src/types/events.ts` — added optional `isForbidden` / `isNotFound` to `OperationResult<T>` (matches BE contract).
+- `src/hooks/useSpotlight.ts` — TanStack Query hooks: packages, payments, checkout, confirm.
+- `src/components/spotlight/SpotlightPurchaseDialog.tsx` — 5-step state machine modal
+  (package → method → processing → success → error). Checkout then immediate confirm
+  (mock gateway auto-approves). Honest "Demo / testläge" badge on payment step.
+- `src/app/my-events/page.tsx` — "Spotlight" button on each event card (entry point) +
+  "Spotlight" badge when an event's spotlight window is active.
+- `src/lib/content/strings-en.ts` — EN archive strings for the new flow.
+
+### Decisions made
+- Entry point = button on the my-events event card (best match for existing UX).
+- Runtime copy is Swedish inline (matches the rest of the app post-#87); EN kept in the archive file.
+- Providers shown: Stripe / Klarna / Swish (the real options to wire later); selected provider
+  is sent to `/checkout`, which the mock gateway auto-approves via the immediate `/confirm` call.
+
+### What's next:
+1. Push branch + open PR when ready.
+2. Wire real payment SDKs later (replace the immediate confirm with provider redirect/webhook return).
+
+## Earlier Task
 **Translate frontend to Swedish — Issue #87** — PR #89 open, issue moved to "In Review".
 
 ### What was done (2026-06-12):

--- a/src/app/my-events/page.tsx
+++ b/src/app/my-events/page.tsx
@@ -13,6 +13,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Loader2,
+  Sparkles,
 } from "lucide-react";
 
 import { Navbar } from "@/components/global/Navbar";
@@ -28,8 +29,15 @@ import {
 } from "@/components/ui/dialog";
 
 import { useEvents, useDeleteEvent } from "@/hooks/useEvents";
+import { SpotlightPurchaseDialog } from "@/components/spotlight/SpotlightPurchaseDialog";
 import type { EventDto } from "@/types/events";
 import { getStoredJwtPayload, getUserIdFromPayload } from "@/lib/jwt";
+
+// An event is "in the spotlight" when it's flagged and the spotlight window hasn't ended.
+function isSpotlightActive(event: EventDto): boolean {
+  if (!event.spotlight || !event.spotlightEndDate) return false;
+  return new Date(event.spotlightEndDate) >= new Date();
+}
 
 function getUserIdFromToken(): string | null {
   const payload = getStoredJwtPayload();
@@ -56,6 +64,9 @@ export default function MyEventsPage() {
 
   // Delete state
   const [deletingEvent, setDeletingEvent] = useState<EventDto | null>(null);
+
+  // Spotlight purchase state
+  const [spotlightEvent, setSpotlightEvent] = useState<EventDto | null>(null);
 
   const events = data?.data?.items || [];
   const totalCount = data?.data?.totalCount || 0;
@@ -156,10 +167,27 @@ export default function MyEventsPage() {
                   <CardHeader className="pb-2">
                     <div className="flex justify-between items-start">
                       <div>
-                        <CardTitle className="text-xl">{event.title}</CardTitle>
+                        <div className="flex items-center gap-2">
+                          <CardTitle className="text-xl">{event.title}</CardTitle>
+                          {isSpotlightActive(event) && (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-[#F3C10E]/20 px-2 py-0.5 text-xs font-medium text-yellow-800">
+                              <Sparkles className="w-3 h-3" />
+                              Spotlight
+                            </span>
+                          )}
+                        </div>
                         <p className="text-sm text-gray-500 mt-1">{event.organiser}</p>
                       </div>
                       <div className="flex gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="gap-1.5 text-yellow-700 hover:text-yellow-800 hover:bg-[#F3C10E]/10"
+                          onClick={() => setSpotlightEvent(event)}
+                        >
+                          <Sparkles className="w-4 h-4" />
+                          <span className="hidden sm:inline">Spotlight</span>
+                        </Button>
                         <Button variant="outline" size="sm" onClick={() => handleEditClick(event)}>
                           <Pencil className="w-4 h-4" />
                         </Button>
@@ -279,6 +307,18 @@ export default function MyEventsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Spotlight Purchase Dialog */}
+      {spotlightEvent && (
+        <SpotlightPurchaseDialog
+          open={!!spotlightEvent}
+          onOpenChange={(open) => {
+            if (!open) setSpotlightEvent(null);
+          }}
+          eventId={spotlightEvent.id}
+          eventTitle={spotlightEvent.title}
+        />
+      )}
     </main>
   );
 }

--- a/src/app/my-events/page.tsx
+++ b/src/app/my-events/page.tsx
@@ -32,12 +32,7 @@ import { useEvents, useDeleteEvent } from "@/hooks/useEvents";
 import { SpotlightPurchaseDialog } from "@/components/spotlight/SpotlightPurchaseDialog";
 import type { EventDto } from "@/types/events";
 import { getStoredJwtPayload, getUserIdFromPayload } from "@/lib/jwt";
-
-// An event is "in the spotlight" when it's flagged and the spotlight window hasn't ended.
-function isSpotlightActive(event: EventDto): boolean {
-  if (!event.spotlight || !event.spotlightEndDate) return false;
-  return new Date(event.spotlightEndDate) >= new Date();
-}
+import { isSpotlightActive } from "@/lib/spotlight";
 
 function getUserIdFromToken(): string | null {
   const payload = getStoredJwtPayload();
@@ -315,8 +310,7 @@ export default function MyEventsPage() {
           onOpenChange={(open) => {
             if (!open) setSpotlightEvent(null);
           }}
-          eventId={spotlightEvent.id}
-          eventTitle={spotlightEvent.title}
+          event={spotlightEvent}
         />
       )}
     </main>

--- a/src/app/spotlight/cancel/page.tsx
+++ b/src/app/spotlight/cancel/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { XCircle } from "lucide-react";
+
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export const metadata = {
+  title: "Betalning avbruten | Go.Do.",
+};
+
+// Stripe redirects here when the organiser aborts or cancels the Checkout.
+// The page is public (no auth guard). Nothing has been charged.
+export default function SpotlightCancelPage() {
+  return (
+    <main className="min-h-screen flex flex-col bg-brand text-black">
+      <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
+        <div className="text-center lg:text-left shrink-0">
+          <h2 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold mb-2 lg:mb-4">Go.Do.</h2>
+          <p className="text-lg sm:text-xl lg:text-2xl">More to do. Close to you.</p>
+        </div>
+
+        <div className="w-full max-w-md">
+          <Card className="shadow-lg border-black/10 bg-white">
+            <CardHeader className="text-center">
+              <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+                <XCircle className="h-6 w-6 text-red-600" />
+              </div>
+              <CardTitle className="text-xl sm:text-2xl font-semibold text-black">
+                Betalningen avbröts
+              </CardTitle>
+            </CardHeader>
+
+            <CardContent className="space-y-3 text-center">
+              <p className="text-black">Inga pengar har dragits.</p>
+              <p className="text-sm text-black/70">
+                Du kan försöka igen när du vill — öppna ditt evenemang under Mina evenemang och
+                klicka på Spotlight.
+              </p>
+            </CardContent>
+
+            <CardFooter className="flex flex-col gap-2">
+              <Link href="/my-events" className="w-full">
+                <Button className="w-full bg-black text-white hover:bg-black/90">
+                  Försök igen — Mina evenemang
+                </Button>
+              </Link>
+              <Link href="/landing" className="w-full">
+                <Button variant="outline" className="w-full">
+                  Till startsidan
+                </Button>
+              </Link>
+            </CardFooter>
+          </Card>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/spotlight/success/page.tsx
+++ b/src/app/spotlight/success/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Sparkles, CheckCircle } from "lucide-react";
+
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+// Stripe redirects here after a completed Checkout with ?session_id=cs_...
+// The page is public (no auth guard) — activation happens server-side via webhook.
+function SpotlightSuccessInner() {
+  const searchParams = useSearchParams();
+  const sessionId = searchParams.get("session_id");
+
+  return (
+    <main className="min-h-screen flex flex-col bg-brand text-black">
+      <section className="flex flex-1 flex-col lg:flex-row items-center justify-center gap-8 lg:gap-16 px-4 sm:px-8 lg:px-16 py-10 lg:py-20">
+        <div className="text-center lg:text-left shrink-0">
+          <h2 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold mb-2 lg:mb-4">Go.Do.</h2>
+          <p className="text-lg sm:text-xl lg:text-2xl">More to do. Close to you.</p>
+        </div>
+
+        <div className="w-full max-w-md">
+          <Card className="shadow-lg border-black/10 bg-white">
+            <CardHeader className="text-center">
+              <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+                <CheckCircle className="h-6 w-6 text-green-600" />
+              </div>
+              <CardTitle className="text-xl sm:text-2xl font-semibold text-black">
+                Betalningen är mottagen
+              </CardTitle>
+              <p className="text-sm text-black/70 mt-2">Tack för ditt köp!</p>
+            </CardHeader>
+
+            <CardContent className="space-y-4 text-center">
+              <div className="flex items-center justify-center gap-2 text-black">
+                <Sparkles className="h-4 w-4 text-[#F3C10E]" />
+                <p>Din spotlight aktiveras inom någon minut.</p>
+              </div>
+              <p className="text-sm text-black/70">
+                Vi bekräftar betalningen automatiskt i bakgrunden — du behöver inte göra något
+                mer. Ett kvitto skickas från Stripe till din e-post.
+              </p>
+              {sessionId && (
+                <p className="text-xs text-black/50 break-all">Referens: {sessionId}</p>
+              )}
+            </CardContent>
+
+            <CardFooter className="flex flex-col gap-2">
+              <Link href="/my-events" className="w-full">
+                <Button className="w-full bg-black text-white hover:bg-black/90">
+                  Till mina evenemang
+                </Button>
+              </Link>
+            </CardFooter>
+          </Card>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default function SpotlightSuccessPage() {
+  return (
+    <React.Suspense fallback={null}>
+      <SpotlightSuccessInner />
+    </React.Suspense>
+  );
+}

--- a/src/components/forms/steps/StepSpotlight.tsx
+++ b/src/components/forms/steps/StepSpotlight.tsx
@@ -10,11 +10,12 @@ import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover
 import { Calendar } from "@/components/ui/calendar";
 import { cn } from "@/lib/utils";
 import { useCloudinaryUpload } from "@/hooks/useCloudinaryUpload";
+import { SPOTLIGHT_PRICE_PER_DAY_SEK } from "@/lib/spotlight";
 
 import type { FormData } from "@/hooks/useEventForm";
 
-const PRICE_PER_DAY = 99; //price
-const VAT_FLAT = 125;     // moms in SEK 
+const PRICE_PER_DAY = SPOTLIGHT_PRICE_PER_DAY_SEK; // shared placeholder price (see lib/spotlight.ts)
+const VAT_FLAT = 125;     // moms in SEK
 
 export function StepSpotlight() {
   const { control, watch, setValue, clearErrors } = useFormContext<FormData>();
@@ -270,7 +271,7 @@ export function StepSpotlight() {
     <div className="rounded-2xl border p-4 bg-muted/30">
       <div className="text-sm">
         <div className="flex justify-between">
-          <span>{days} dagar × 99 kr</span>
+          <span>{days} dagar × {PRICE_PER_DAY} kr</span>
           <span className="font-medium">{fmt.format(subtotal)}</span>
         </div>
         <div className="flex justify-between mt-1">
@@ -284,7 +285,7 @@ export function StepSpotlight() {
         </div>
       </div>
       <p className="text-xs text-muted-foreground mt-2">
-        Priset är 99 kr per dag plus 125 kr moms. Momsen ingår i totalpriset.
+        Priset är {PRICE_PER_DAY} kr per dag plus {VAT_FLAT} kr moms. Momsen ingår i totalpriset.
       </p>
     </div>
   </>

--- a/src/components/spotlight/SpotlightPurchaseDialog.tsx
+++ b/src/components/spotlight/SpotlightPurchaseDialog.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import * as React from "react";
+import { toast } from "sonner";
+import { Sparkles, Loader2, Check, CreditCard, AlertCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import {
+  useSpotlightPackages,
+  useSpotlightCheckout,
+  useSpotlightConfirm,
+} from "@/hooks/useSpotlight";
+import type { SpotlightPackage, SpotlightProvider } from "@/types/spotlight";
+
+type Step = "package" | "method" | "processing" | "success" | "error";
+
+// The real providers we'll wire later. Payments are simulated for now (mock gateway).
+const PROVIDERS: { id: SpotlightProvider; label: string }[] = [
+  { id: "stripe", label: "Stripe" },
+  { id: "klarna", label: "Klarna" },
+  { id: "swish", label: "Swish" },
+];
+
+const sek = (amount: number, currency: string) =>
+  new Intl.NumberFormat("sv-SE", {
+    style: "currency",
+    currency: currency || "SEK",
+    maximumFractionDigits: 0,
+  }).format(amount);
+
+const formatDate = (dateStr?: string | null) => {
+  if (!dateStr) return "-";
+  return new Date(dateStr).toLocaleDateString("sv-SE");
+};
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  eventId: string;
+  eventTitle: string;
+};
+
+export function SpotlightPurchaseDialog({ open, onOpenChange, eventId, eventTitle }: Props) {
+  const [step, setStep] = React.useState<Step>("package");
+  const [selectedPackage, setSelectedPackage] = React.useState<SpotlightPackage | null>(null);
+  const [provider, setProvider] = React.useState<SpotlightProvider>("stripe");
+  const [endDate, setEndDate] = React.useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = React.useState<string>("");
+
+  const { data: packagesResult, isLoading: isLoadingPackages } = useSpotlightPackages();
+  const checkout = useSpotlightCheckout();
+  const confirm = useSpotlightConfirm();
+
+  const packages = packagesResult?.data ?? [];
+
+  // Reset internal state whenever the dialog is (re)opened.
+  React.useEffect(() => {
+    if (open) {
+      setStep("package");
+      setSelectedPackage(null);
+      setProvider("stripe");
+      setEndDate(null);
+      setErrorMessage("");
+    }
+  }, [open]);
+
+  const handlePurchase = async () => {
+    if (!selectedPackage) return;
+    setStep("processing");
+    setErrorMessage("");
+
+    try {
+      // 1) Start checkout (owner-only).
+      const checkoutResult = await checkout.mutateAsync({
+        eventId,
+        packageCode: selectedPackage.code,
+        provider,
+      });
+
+      if (!checkoutResult.isSuccess) {
+        setErrorMessage(
+          checkoutResult.isForbidden
+            ? "Du kan bara lyfta fram evenemang som du själv äger."
+            : checkoutResult.errors?.[0] || "Det gick inte att starta betalningen."
+        );
+        setStep("error");
+        return;
+      }
+
+      // 2) Immediately confirm — the mock gateway auto-approves (stands in for the
+      //    provider webhook/redirect-return). On success the spotlight goes live.
+      const confirmResult = await confirm.mutateAsync({
+        paymentId: checkoutResult.data.paymentId,
+      });
+
+      if (!confirmResult.isSuccess) {
+        setErrorMessage(confirmResult.errors?.[0] || "Det gick inte att bekräfta betalningen.");
+        setStep("error");
+        return;
+      }
+
+      setEndDate(confirmResult.data.spotlightEndDate);
+      setStep("success");
+      toast.success("Ditt evenemang är nu i spotlight");
+    } catch (err: unknown) {
+      // Axios throws on 4xx (e.g. 403 for non-owners).
+      const status =
+        typeof err === "object" && err !== null && "response" in err
+          ? (err as { response?: { status?: number } }).response?.status
+          : undefined;
+      setErrorMessage(
+        status === 403
+          ? "Du kan bara lyfta fram evenemang som du själv äger."
+          : "Något gick fel. Försök igen senare."
+      );
+      setStep("error");
+    }
+  };
+
+  const isProcessing = step === "processing";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-[#F3C10E]" />
+            Lyft fram evenemang
+          </DialogTitle>
+          <DialogDescription>{eventTitle}</DialogDescription>
+        </DialogHeader>
+
+        {/* STEP 1 — choose a package */}
+        {step === "package" && (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Välj hur länge ditt evenemang ska visas i spotlight.
+            </p>
+
+            {isLoadingPackages && (
+              <div className="flex justify-center py-8">
+                <Loader2 className="h-6 w-6 animate-spin" />
+              </div>
+            )}
+
+            {!isLoadingPackages && packages.length === 0 && (
+              <p className="text-sm text-destructive">
+                Det gick inte att hämta paket. Försök igen.
+              </p>
+            )}
+
+            <div className="space-y-2">
+              {packages.map((pkg) => {
+                const active = selectedPackage?.code === pkg.code;
+                return (
+                  <button
+                    key={pkg.code}
+                    type="button"
+                    onClick={() => setSelectedPackage(pkg)}
+                    className={cn(
+                      "flex w-full items-center justify-between rounded-xl border p-4 text-left transition-colors",
+                      active
+                        ? "border-[#F3C10E] bg-[#F3C10E]/10 ring-1 ring-[#F3C10E]"
+                        : "hover:border-[#F3C10E]/60"
+                    )}
+                  >
+                    <div>
+                      <p className="font-medium">{pkg.name}</p>
+                      <p className="text-sm text-muted-foreground">{pkg.durationDays} dagar</p>
+                    </div>
+                    <span className="text-base font-semibold">
+                      {sek(pkg.amount, pkg.currency)}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <Button
+              className="w-full"
+              disabled={!selectedPackage}
+              onClick={() => setStep("method")}
+            >
+              Fortsätt
+            </Button>
+          </div>
+        )}
+
+        {/* STEP 2 — choose a payment method */}
+        {step === "method" && selectedPackage && (
+          <div className="space-y-4">
+            <div className="rounded-xl border bg-muted/30 p-3 text-sm">
+              <div className="flex justify-between">
+                <span>{selectedPackage.name}</span>
+                <span className="font-medium">
+                  {sek(selectedPackage.amount, selectedPackage.currency)}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {selectedPackage.durationDays} dagar i spotlight
+              </p>
+            </div>
+
+            <div>
+              <p className="mb-2 text-sm font-medium">Välj betalsätt</p>
+              <div className="grid grid-cols-3 gap-2">
+                {PROVIDERS.map((p) => {
+                  const active = provider === p.id;
+                  return (
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => setProvider(p.id)}
+                      className={cn(
+                        "flex h-16 flex-col items-center justify-center gap-1 rounded-xl border text-sm font-medium transition-colors",
+                        active
+                          ? "border-[#F3C10E] bg-[#F3C10E]/10 ring-1 ring-[#F3C10E]"
+                          : "hover:border-[#F3C10E]/60"
+                      )}
+                    >
+                      <CreditCard className="h-4 w-4 text-muted-foreground" />
+                      {p.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Honest note: payments are simulated for now. */}
+            <div className="flex items-start gap-2 rounded-lg bg-amber-50 p-3 text-xs text-amber-800">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                <span className="font-semibold">Demo / testläge.</span> Betalningar simuleras just
+                nu — inga riktiga pengar dras. Riktig betalning kopplas på senare.
+              </span>
+            </div>
+
+            <div className="flex gap-2">
+              <Button variant="outline" className="flex-1" onClick={() => setStep("package")}>
+                Tillbaka
+              </Button>
+              <Button className="flex-1" onClick={handlePurchase}>
+                Betala {sek(selectedPackage.amount, selectedPackage.currency)}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* STEP 3 — processing */}
+        {isProcessing && (
+          <div className="flex flex-col items-center gap-3 py-10">
+            <Loader2 className="h-8 w-8 animate-spin text-[#F3C10E]" />
+            <p className="text-sm text-muted-foreground">Behandlar betalningen…</p>
+          </div>
+        )}
+
+        {/* STEP 4 — success */}
+        {step === "success" && (
+          <div className="flex flex-col items-center gap-3 py-6 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+              <Check className="h-6 w-6 text-green-600" />
+            </div>
+            <p className="font-medium">Betalningen lyckades</p>
+            <p className="text-sm text-muted-foreground">
+              Ditt evenemang är nu i spotlight till och med{" "}
+              <span className="font-medium text-foreground">{formatDate(endDate)}</span>.
+            </p>
+            <Button className="mt-2 w-full" onClick={() => onOpenChange(false)}>
+              Klar
+            </Button>
+          </div>
+        )}
+
+        {/* STEP 5 — error */}
+        {step === "error" && (
+          <div className="flex flex-col items-center gap-3 py-6 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+              <AlertCircle className="h-6 w-6 text-red-600" />
+            </div>
+            <p className="font-medium">Något gick fel</p>
+            <p className="text-sm text-muted-foreground">{errorMessage}</p>
+            <div className="mt-2 flex w-full gap-2">
+              <Button variant="outline" className="flex-1" onClick={() => onOpenChange(false)}>
+                Stäng
+              </Button>
+              <Button className="flex-1" onClick={() => setStep("package")}>
+                Försök igen
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/spotlight/SpotlightPurchaseDialog.tsx
+++ b/src/components/spotlight/SpotlightPurchaseDialog.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import * as React from "react";
-import { toast } from "sonner";
-import { Sparkles, Loader2, Check, CreditCard, AlertCircle } from "lucide-react";
+import { format } from "date-fns";
+import { Sparkles, Loader2, AlertCircle, Calendar as CalendarIcon, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import {
   Dialog,
   DialogContent,
@@ -13,28 +17,21 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+import { useSpotlightCheckout } from "@/hooks/useSpotlight";
 import {
-  useSpotlightPackages,
-  useSpotlightCheckout,
-  useSpotlightConfirm,
-} from "@/hooks/useSpotlight";
-import type { SpotlightPackage, SpotlightProvider } from "@/types/spotlight";
+  SPOTLIGHT_PRICE_PER_DAY_SEK,
+  SPOTLIGHT_MIN_DAYS,
+  SPOTLIGHT_MAX_DAYS,
+  formatSek,
+  isSpotlightActive,
+  isSpotlightScheduled,
+} from "@/lib/spotlight";
+import type { EventDto } from "@/types/events";
 
-type Step = "package" | "method" | "processing" | "success" | "error";
+type Step = "configure" | "redirecting" | "error";
 
-// The real providers we'll wire later. Payments are simulated for now (mock gateway).
-const PROVIDERS: { id: SpotlightProvider; label: string }[] = [
-  { id: "stripe", label: "Stripe" },
-  { id: "klarna", label: "Klarna" },
-  { id: "swish", label: "Swish" },
-];
-
-const sek = (amount: number, currency: string) =>
-  new Intl.NumberFormat("sv-SE", {
-    style: "currency",
-    currency: currency || "SEK",
-    maximumFractionDigits: 0,
-  }).format(amount);
+// Quick-select durations shown as preset chips (custom input covers the rest).
+const PRESET_DAYS = [7, 14, 30];
 
 const formatDate = (dateStr?: string | null) => {
   if (!dateStr) return "-";
@@ -44,88 +41,104 @@ const formatDate = (dateStr?: string | null) => {
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  eventId: string;
-  eventTitle: string;
+  event: EventDto;
 };
 
-export function SpotlightPurchaseDialog({ open, onOpenChange, eventId, eventTitle }: Props) {
-  const [step, setStep] = React.useState<Step>("package");
-  const [selectedPackage, setSelectedPackage] = React.useState<SpotlightPackage | null>(null);
-  const [provider, setProvider] = React.useState<SpotlightProvider>("stripe");
-  const [endDate, setEndDate] = React.useState<string | null>(null);
+export function SpotlightPurchaseDialog({ open, onOpenChange, event }: Props) {
+  const [step, setStep] = React.useState<Step>("configure");
+  const [days, setDays] = React.useState<number>(7);
+  const [daysInput, setDaysInput] = React.useState<string>("7");
+  const [startDate, setStartDate] = React.useState<Date | undefined>(undefined);
   const [errorMessage, setErrorMessage] = React.useState<string>("");
 
-  const { data: packagesResult, isLoading: isLoadingPackages } = useSpotlightPackages();
   const checkout = useSpotlightCheckout();
-  const confirm = useSpotlightConfirm();
 
-  const packages = packagesResult?.data ?? [];
+  const today = React.useMemo(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }, []);
 
   // Reset internal state whenever the dialog is (re)opened.
   React.useEffect(() => {
     if (open) {
-      setStep("package");
-      setSelectedPackage(null);
-      setProvider("stripe");
-      setEndDate(null);
+      setStep("configure");
+      setDays(7);
+      setDaysInput("7");
+      setStartDate(undefined);
       setErrorMessage("");
+      checkout.reset();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
+  const spotlightActive = isSpotlightActive(event);
+  const spotlightScheduled = isSpotlightScheduled(event);
+
+  const daysValid =
+    Number.isInteger(days) && days >= SPOTLIGHT_MIN_DAYS && days <= SPOTLIGHT_MAX_DAYS;
+  const total = daysValid ? days * SPOTLIGHT_PRICE_PER_DAY_SEK : 0;
+
+  const handleDaysInput = (raw: string) => {
+    setDaysInput(raw);
+    const parsed = Number.parseInt(raw, 10);
+    setDays(Number.isNaN(parsed) ? 0 : parsed);
+  };
+
+  const selectPreset = (d: number) => {
+    setDays(d);
+    setDaysInput(String(d));
+  };
+
   const handlePurchase = async () => {
-    if (!selectedPackage) return;
-    setStep("processing");
+    if (!daysValid || checkout.isPending) return;
     setErrorMessage("");
 
     try {
-      // 1) Start checkout (owner-only).
-      const checkoutResult = await checkout.mutateAsync({
-        eventId,
-        packageCode: selectedPackage.code,
-        provider,
+      const result = await checkout.mutateAsync({
+        eventId: event.id,
+        body: {
+          days,
+          // Omitted = starts today (backend default). Send as ISO date only.
+          ...(startDate ? { startDate: format(startDate, "yyyy-MM-dd") } : {}),
+        },
       });
 
-      if (!checkoutResult.isSuccess) {
+      if (!result.isSuccess || !result.data?.checkoutUrl) {
         setErrorMessage(
-          checkoutResult.isForbidden
+          result.isForbidden
             ? "Du kan bara lyfta fram evenemang som du själv äger."
-            : checkoutResult.errors?.[0] || "Det gick inte att starta betalningen."
+            : result.errors?.join(", ") || "Det gick inte att starta betalningen."
         );
         setStep("error");
         return;
       }
 
-      // 2) Immediately confirm — the mock gateway auto-approves (stands in for the
-      //    provider webhook/redirect-return). On success the spotlight goes live.
-      const confirmResult = await confirm.mutateAsync({
-        paymentId: checkoutResult.data.paymentId,
-      });
-
-      if (!confirmResult.isSuccess) {
-        setErrorMessage(confirmResult.errors?.[0] || "Det gick inte att bekräfta betalningen.");
-        setStep("error");
-        return;
-      }
-
-      setEndDate(confirmResult.data.spotlightEndDate);
-      setStep("success");
-      toast.success("Ditt evenemang är nu i spotlight");
+      // Hand the browser over to Stripe's hosted checkout page.
+      setStep("redirecting");
+      window.location.href = result.data.checkoutUrl;
     } catch (err: unknown) {
-      // Axios throws on 4xx (e.g. 403 for non-owners).
-      const status =
+      // Axios throws on 4xx. Surface the backend's errors[] when present.
+      const resp =
         typeof err === "object" && err !== null && "response" in err
-          ? (err as { response?: { status?: number } }).response?.status
+          ? (err as { response?: { status?: number; data?: { errors?: string[] } } }).response
           : undefined;
-      setErrorMessage(
-        status === 403
-          ? "Du kan bara lyfta fram evenemang som du själv äger."
-          : "Något gick fel. Försök igen senare."
-      );
+      const backendErrors = resp?.data?.errors?.filter(Boolean) ?? [];
+
+      if (resp?.status === 403) {
+        setErrorMessage("Du kan bara lyfta fram evenemang som du själv äger.");
+      } else if (resp?.status === 404) {
+        setErrorMessage("Evenemanget hittades inte eller är inte längre aktivt.");
+      } else if (backendErrors.length > 0) {
+        setErrorMessage(backendErrors.join(", "));
+      } else {
+        setErrorMessage("Något gick fel. Försök igen senare.");
+      }
       setStep("error");
     }
   };
 
-  const isProcessing = step === "processing";
+  const isBusy = checkout.isPending || step === "redirecting";
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -135,151 +148,150 @@ export function SpotlightPurchaseDialog({ open, onOpenChange, eventId, eventTitl
             <Sparkles className="h-5 w-5 text-[#F3C10E]" />
             Lyft fram evenemang
           </DialogTitle>
-          <DialogDescription>{eventTitle}</DialogDescription>
+          <DialogDescription>{event.title}</DialogDescription>
         </DialogHeader>
 
-        {/* STEP 1 — choose a package */}
-        {step === "package" && (
+        {/* Already purchased — show the current window. */}
+        {step === "configure" && (spotlightActive || spotlightScheduled) && (
+          <div className="flex items-start gap-2 rounded-xl border border-[#F3C10E] bg-[#F3C10E]/10 p-3 text-sm">
+            <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-yellow-700" />
+            <span>
+              {spotlightActive ? (
+                <>
+                  Evenemanget är i spotlight till och med{" "}
+                  <span className="font-semibold">{formatDate(event.spotlightEndDate)}</span>.
+                </>
+              ) : (
+                <>
+                  Spotlight är bokad{" "}
+                  <span className="font-semibold">{formatDate(event.spotlightStartDate)}</span> –{" "}
+                  <span className="font-semibold">{formatDate(event.spotlightEndDate)}</span>.
+                </>
+              )}
+            </span>
+          </div>
+        )}
+
+        {/* STEP 1 — configure duration + start date */}
+        {step === "configure" && (
           <div className="space-y-4">
             <p className="text-sm text-muted-foreground">
               Välj hur länge ditt evenemang ska visas i spotlight.
             </p>
 
-            {isLoadingPackages && (
-              <div className="flex justify-center py-8">
-                <Loader2 className="h-6 w-6 animate-spin" />
-              </div>
-            )}
-
-            {!isLoadingPackages && packages.length === 0 && (
-              <p className="text-sm text-destructive">
-                Det gick inte att hämta paket. Försök igen.
-              </p>
-            )}
-
-            <div className="space-y-2">
-              {packages.map((pkg) => {
-                const active = selectedPackage?.code === pkg.code;
+            <div className="grid grid-cols-3 gap-2">
+              {PRESET_DAYS.map((d) => {
+                const active = days === d;
                 return (
                   <button
-                    key={pkg.code}
+                    key={d}
                     type="button"
-                    onClick={() => setSelectedPackage(pkg)}
+                    onClick={() => selectPreset(d)}
                     className={cn(
-                      "flex w-full items-center justify-between rounded-xl border p-4 text-left transition-colors",
+                      "flex h-16 flex-col items-center justify-center gap-0.5 rounded-xl border text-sm font-medium transition-colors",
                       active
                         ? "border-[#F3C10E] bg-[#F3C10E]/10 ring-1 ring-[#F3C10E]"
                         : "hover:border-[#F3C10E]/60"
                     )}
                   >
-                    <div>
-                      <p className="font-medium">{pkg.name}</p>
-                      <p className="text-sm text-muted-foreground">{pkg.durationDays} dagar</p>
-                    </div>
-                    <span className="text-base font-semibold">
-                      {sek(pkg.amount, pkg.currency)}
+                    <span className="text-base font-semibold">{d} dagar</span>
+                    <span className="text-xs text-muted-foreground">
+                      {formatSek(d * SPOTLIGHT_PRICE_PER_DAY_SEK)}
                     </span>
                   </button>
                 );
               })}
             </div>
 
-            <Button
-              className="w-full"
-              disabled={!selectedPackage}
-              onClick={() => setStep("method")}
-            >
-              Fortsätt
-            </Button>
-          </div>
-        )}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label htmlFor="spotlight-days" className="mb-1 block">
+                  Antal dagar
+                </Label>
+                <Input
+                  id="spotlight-days"
+                  type="number"
+                  min={SPOTLIGHT_MIN_DAYS}
+                  max={SPOTLIGHT_MAX_DAYS}
+                  step={1}
+                  value={daysInput}
+                  onChange={(e) => handleDaysInput(e.target.value)}
+                />
+                {!daysValid && daysInput !== "" && (
+                  <p className="mt-1 text-xs text-destructive">
+                    Ange mellan {SPOTLIGHT_MIN_DAYS} och {SPOTLIGHT_MAX_DAYS} dagar.
+                  </p>
+                )}
+              </div>
 
-        {/* STEP 2 — choose a payment method */}
-        {step === "method" && selectedPackage && (
-          <div className="space-y-4">
+              <div>
+                <Label className="mb-1 block">Startdatum (valfritt)</Label>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className={cn(
+                        "w-full justify-start text-left font-normal",
+                        !startDate && "text-muted-foreground"
+                      )}
+                    >
+                      <CalendarIcon className="mr-2 h-4 w-4" />
+                      {startDate ? format(startDate, "dd.MM.yyyy") : "Startar idag"}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0" align="start">
+                    <Calendar
+                      mode="single"
+                      selected={startDate}
+                      onSelect={(d) => setStartDate(d ?? undefined)}
+                      disabled={{ before: today }}
+                      initialFocus
+                    />
+                  </PopoverContent>
+                </Popover>
+                {startDate && (
+                  <button
+                    type="button"
+                    onClick={() => setStartDate(undefined)}
+                    className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    <X className="h-3 w-3" />
+                    Rensa — starta idag
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Price summary */}
             <div className="rounded-xl border bg-muted/30 p-3 text-sm">
               <div className="flex justify-between">
-                <span>{selectedPackage.name}</span>
-                <span className="font-medium">
-                  {sek(selectedPackage.amount, selectedPackage.currency)}
+                <span>
+                  {daysValid ? days : "–"} dagar × {formatSek(SPOTLIGHT_PRICE_PER_DAY_SEK)}
                 </span>
+                <span className="font-semibold">{daysValid ? formatSek(total) : "–"}</span>
               </div>
               <p className="mt-1 text-xs text-muted-foreground">
-                {selectedPackage.durationDays} dagar i spotlight
+                Priset är {formatSek(SPOTLIGHT_PRICE_PER_DAY_SEK)} per dag. Du skickas till Stripe
+                för säker betalning.
               </p>
             </div>
 
-            <div>
-              <p className="mb-2 text-sm font-medium">Välj betalsätt</p>
-              <div className="grid grid-cols-3 gap-2">
-                {PROVIDERS.map((p) => {
-                  const active = provider === p.id;
-                  return (
-                    <button
-                      key={p.id}
-                      type="button"
-                      onClick={() => setProvider(p.id)}
-                      className={cn(
-                        "flex h-16 flex-col items-center justify-center gap-1 rounded-xl border text-sm font-medium transition-colors",
-                        active
-                          ? "border-[#F3C10E] bg-[#F3C10E]/10 ring-1 ring-[#F3C10E]"
-                          : "hover:border-[#F3C10E]/60"
-                      )}
-                    >
-                      <CreditCard className="h-4 w-4 text-muted-foreground" />
-                      {p.label}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-
-            {/* Honest note: payments are simulated for now. */}
-            <div className="flex items-start gap-2 rounded-lg bg-amber-50 p-3 text-xs text-amber-800">
-              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>
-                <span className="font-semibold">Demo / testläge.</span> Betalningar simuleras just
-                nu — inga riktiga pengar dras. Riktig betalning kopplas på senare.
-              </span>
-            </div>
-
-            <div className="flex gap-2">
-              <Button variant="outline" className="flex-1" onClick={() => setStep("package")}>
-                Tillbaka
-              </Button>
-              <Button className="flex-1" onClick={handlePurchase}>
-                Betala {sek(selectedPackage.amount, selectedPackage.currency)}
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* STEP 3 — processing */}
-        {isProcessing && (
-          <div className="flex flex-col items-center gap-3 py-10">
-            <Loader2 className="h-8 w-8 animate-spin text-[#F3C10E]" />
-            <p className="text-sm text-muted-foreground">Behandlar betalningen…</p>
-          </div>
-        )}
-
-        {/* STEP 4 — success */}
-        {step === "success" && (
-          <div className="flex flex-col items-center gap-3 py-6 text-center">
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
-              <Check className="h-6 w-6 text-green-600" />
-            </div>
-            <p className="font-medium">Betalningen lyckades</p>
-            <p className="text-sm text-muted-foreground">
-              Ditt evenemang är nu i spotlight till och med{" "}
-              <span className="font-medium text-foreground">{formatDate(endDate)}</span>.
-            </p>
-            <Button className="mt-2 w-full" onClick={() => onOpenChange(false)}>
-              Klar
+            <Button className="w-full" disabled={!daysValid || isBusy} onClick={handlePurchase}>
+              {isBusy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isBusy ? "Startar betalning…" : `Betala ${daysValid ? formatSek(total) : ""}`}
             </Button>
           </div>
         )}
 
-        {/* STEP 5 — error */}
+        {/* STEP 2 — redirecting to Stripe */}
+        {step === "redirecting" && (
+          <div className="flex flex-col items-center gap-3 py-10">
+            <Loader2 className="h-8 w-8 animate-spin text-[#F3C10E]" />
+            <p className="text-sm text-muted-foreground">Skickar dig till betalningen…</p>
+          </div>
+        )}
+
+        {/* STEP 3 — error */}
         {step === "error" && (
           <div className="flex flex-col items-center gap-3 py-6 text-center">
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
@@ -291,7 +303,7 @@ export function SpotlightPurchaseDialog({ open, onOpenChange, eventId, eventTitl
               <Button variant="outline" className="flex-1" onClick={() => onOpenChange(false)}>
                 Stäng
               </Button>
-              <Button className="flex-1" onClick={() => setStep("package")}>
+              <Button className="flex-1" onClick={() => setStep("configure")}>
                 Försök igen
               </Button>
             </div>

--- a/src/hooks/useSpotlight.ts
+++ b/src/hooks/useSpotlight.ts
@@ -1,0 +1,70 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/axios";
+import { OperationResult } from "@/types/events";
+import {
+  SpotlightPackage,
+  SpotlightCheckoutRequest,
+  SpotlightCheckoutResponse,
+  SpotlightConfirmRequest,
+  SpotlightPayment,
+} from "@/types/spotlight";
+
+// GET /api/spotlight/packages — public catalogue (no auth required)
+export function useSpotlightPackages() {
+  return useQuery({
+    queryKey: ["spotlight-packages"],
+    queryFn: async () => {
+      const response =
+        await api.get<OperationResult<SpotlightPackage[]>>("/spotlight/packages");
+      return response.data;
+    },
+    staleTime: 1000 * 60 * 10, // catalogue rarely changes
+  });
+}
+
+// GET /api/spotlight/payments — caller's purchase history
+export function useSpotlightPayments(enabled = true) {
+  return useQuery({
+    queryKey: ["spotlight-payments"],
+    queryFn: async () => {
+      const response =
+        await api.get<OperationResult<SpotlightPayment[]>>("/spotlight/payments");
+      return response.data;
+    },
+    enabled,
+  });
+}
+
+// POST /api/spotlight/checkout — start a payment (owner only)
+export function useSpotlightCheckout() {
+  return useMutation({
+    mutationFn: async (body: SpotlightCheckoutRequest) => {
+      const response = await api.post<OperationResult<SpotlightCheckoutResponse>>(
+        "/spotlight/checkout",
+        body
+      );
+      return response.data;
+    },
+  });
+}
+
+// POST /api/spotlight/confirm — mock stand-in for the provider webhook/redirect.
+// On success the event's spotlight goes live.
+export function useSpotlightConfirm() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (body: SpotlightConfirmRequest) => {
+      const response = await api.post<OperationResult<SpotlightPayment>>(
+        "/spotlight/confirm",
+        body
+      );
+      return response.data;
+    },
+    onSuccess: () => {
+      // Event spotlight state changed — refresh events + payment history.
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+      queryClient.invalidateQueries({ queryKey: ["spotlight-payments"] });
+    },
+  });
+}

--- a/src/hooks/useSpotlight.ts
+++ b/src/hooks/useSpotlight.ts
@@ -1,70 +1,27 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { api } from "@/lib/axios";
 import { OperationResult } from "@/types/events";
-import {
-  SpotlightPackage,
-  SpotlightCheckoutRequest,
-  SpotlightCheckoutResponse,
-  SpotlightConfirmRequest,
-  SpotlightPayment,
-} from "@/types/spotlight";
+import { SpotlightCheckoutRequest, SpotlightCheckoutResponse } from "@/types/spotlight";
 
-// GET /api/spotlight/packages — public catalogue (no auth required)
-export function useSpotlightPackages() {
-  return useQuery({
-    queryKey: ["spotlight-packages"],
-    queryFn: async () => {
-      const response =
-        await api.get<OperationResult<SpotlightPackage[]>>("/spotlight/packages");
-      return response.data;
-    },
-    staleTime: 1000 * 60 * 10, // catalogue rarely changes
-  });
-}
-
-// GET /api/spotlight/payments — caller's purchase history
-export function useSpotlightPayments(enabled = true) {
-  return useQuery({
-    queryKey: ["spotlight-payments"],
-    queryFn: async () => {
-      const response =
-        await api.get<OperationResult<SpotlightPayment[]>>("/spotlight/payments");
-      return response.data;
-    },
-    enabled,
-  });
-}
-
-// POST /api/spotlight/checkout — start a payment (owner only)
+// POST /api/events/{eventId}/spotlight/checkout — start a Stripe Checkout
+// session for the event (owner only). On success redirect the browser to
+// data.checkoutUrl. Payment confirmation is webhook-driven server-side;
+// Stripe sends the browser back to /spotlight/success or /spotlight/cancel.
 export function useSpotlightCheckout() {
   return useMutation({
-    mutationFn: async (body: SpotlightCheckoutRequest) => {
+    mutationFn: async ({
+      eventId,
+      body,
+    }: {
+      eventId: string;
+      body: SpotlightCheckoutRequest;
+    }) => {
       const response = await api.post<OperationResult<SpotlightCheckoutResponse>>(
-        "/spotlight/checkout",
+        `/events/${eventId}/spotlight/checkout`,
         body
       );
       return response.data;
     },
-  });
-}
-
-// POST /api/spotlight/confirm — mock stand-in for the provider webhook/redirect.
-// On success the event's spotlight goes live.
-export function useSpotlightConfirm() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async (body: SpotlightConfirmRequest) => {
-      const response = await api.post<OperationResult<SpotlightPayment>>(
-        "/spotlight/confirm",
-        body
-      );
-      return response.data;
-    },
-    onSuccess: () => {
-      // Event spotlight state changed — refresh events + payment history.
-      queryClient.invalidateQueries({ queryKey: ["events"] });
-      queryClient.invalidateQueries({ queryKey: ["spotlight-payments"] });
-    },
+    retry: false, // never retry — each call creates a new Stripe session
   });
 }

--- a/src/lib/content/strings-en.ts
+++ b/src/lib/content/strings-en.ts
@@ -87,33 +87,52 @@ export const EN = {
     priceNote: "The price is 99 SEK per day plus 125 SEK VAT. VAT is included in the total",
   },
 
-  // SpotlightPurchaseDialog (my-events spotlight placement purchase flow)
+  // SpotlightPurchaseDialog (my-events spotlight placement purchase — Stripe Checkout)
   spotlightPurchase: {
     title: "Spotlight your event",
-    choosePackagePrompt: "Choose how long your event stays in the spotlight.",
-    packagesError: "Could not load packages. Please try again.",
-    continue: "Continue",
+    chooseDurationPrompt: "Choose how long your event stays in the spotlight.",
     days: "{days} days",
-    daysInSpotlight: "{days} days in the spotlight",
-    choosePaymentMethod: "Choose a payment method",
-    demoBadgeTitle: "Demo / test mode.",
-    demoBadgeBody:
-      "Payments are simulated for now — no real money is charged. Real payments will be wired up later.",
-    back: "Back",
-    pay: "Pay",
-    processing: "Processing payment…",
-    paymentSuccess: "Payment successful",
-    spotlightUntil: "Your event is now in the spotlight until {date}.",
-    done: "Done",
+    daysLabel: "Number of days",
+    daysRange: "Enter between {min} and {max} days.",
+    startDateLabel: "Start date (optional)",
+    startsToday: "Starts today",
+    clearStartDate: "Clear — start today",
+    daysPrice: "{days} days × {price}",
+    priceNote: "The price is {price} per day. You will be sent to Stripe for secure payment.",
+    pay: "Pay {total}",
+    startingPayment: "Starting payment…",
+    redirecting: "Sending you to the payment…",
+    activeUntil: "The event is in the spotlight until {date}.",
+    scheduled: "Spotlight is booked {startDate} – {endDate}.",
     errorTitle: "Something went wrong",
     forbidden: "You can only spotlight events that you own.",
+    notFound: "The event was not found or is no longer active.",
     checkoutFailed: "Could not start the payment.",
-    confirmFailed: "Could not confirm the payment.",
     genericError: "Something went wrong. Please try again later.",
     close: "Close",
     retry: "Try again",
     badge: "Spotlight",
-    toastSuccess: "Your event is now in the spotlight",
+  },
+
+  // /spotlight/success (Stripe redirect after completed payment)
+  spotlightSuccess: {
+    title: "Payment received",
+    thanks: "Thank you for your purchase!",
+    activating: "Your spotlight activates within a minute or two.",
+    autoConfirm:
+      "We confirm the payment automatically in the background — nothing more to do. A receipt is sent from Stripe to your email.",
+    reference: "Reference: {sessionId}",
+    ctaMyEvents: "To my events",
+  },
+
+  // /spotlight/cancel (Stripe redirect after aborted payment)
+  spotlightCancel: {
+    title: "Payment cancelled",
+    nothingCharged: "No money has been charged.",
+    tryAgainHint:
+      "You can try again anytime — open your event under My Events and click Spotlight.",
+    ctaTryAgain: "Try again — My Events",
+    ctaHome: "To the start page",
   },
 
   // StepEventReview

--- a/src/lib/content/strings-en.ts
+++ b/src/lib/content/strings-en.ts
@@ -87,6 +87,35 @@ export const EN = {
     priceNote: "The price is 99 SEK per day plus 125 SEK VAT. VAT is included in the total",
   },
 
+  // SpotlightPurchaseDialog (my-events spotlight placement purchase flow)
+  spotlightPurchase: {
+    title: "Spotlight your event",
+    choosePackagePrompt: "Choose how long your event stays in the spotlight.",
+    packagesError: "Could not load packages. Please try again.",
+    continue: "Continue",
+    days: "{days} days",
+    daysInSpotlight: "{days} days in the spotlight",
+    choosePaymentMethod: "Choose a payment method",
+    demoBadgeTitle: "Demo / test mode.",
+    demoBadgeBody:
+      "Payments are simulated for now — no real money is charged. Real payments will be wired up later.",
+    back: "Back",
+    pay: "Pay",
+    processing: "Processing payment…",
+    paymentSuccess: "Payment successful",
+    spotlightUntil: "Your event is now in the spotlight until {date}.",
+    done: "Done",
+    errorTitle: "Something went wrong",
+    forbidden: "You can only spotlight events that you own.",
+    checkoutFailed: "Could not start the payment.",
+    confirmFailed: "Could not confirm the payment.",
+    genericError: "Something went wrong. Please try again later.",
+    close: "Close",
+    retry: "Try again",
+    badge: "Spotlight",
+    toastSuccess: "Your event is now in the spotlight",
+  },
+
   // StepEventReview
   review: {
     heading: "Review your event info",

--- a/src/lib/spotlight.ts
+++ b/src/lib/spotlight.ts
@@ -1,0 +1,40 @@
+// Shared spotlight pricing + helpers.
+// Keep ALL spotlight price knowledge in this file — components must import from here.
+
+import type { EventDto } from "@/types/events";
+
+// PLACEHOLDER PRICE: 99 SEK/day is pending product-owner confirmation.
+// The authoritative price lives in the backend Stripe checkout — this constant
+// is display-only and must be kept in sync with it.
+export const SPOTLIGHT_PRICE_PER_DAY_SEK = 99;
+
+// Allowed purchase duration (mirrors backend validation: days 1–90).
+export const SPOTLIGHT_MIN_DAYS = 1;
+export const SPOTLIGHT_MAX_DAYS = 90;
+
+// Formats whole-SEK amounts, e.g. "693 kr".
+export const formatSek = (amount: number) =>
+  new Intl.NumberFormat("sv-SE", {
+    style: "currency",
+    currency: "SEK",
+    maximumFractionDigits: 0,
+  }).format(amount);
+
+type SpotlightFields = Pick<EventDto, "spotlight" | "spotlightStartDate" | "spotlightEndDate">;
+
+// An event is "in the spotlight" when it's flagged, the window has started
+// (or has no start date) and the window hasn't ended.
+export function isSpotlightActive(event: SpotlightFields): boolean {
+  if (!event.spotlight || !event.spotlightEndDate) return false;
+  const now = new Date();
+  if (new Date(event.spotlightEndDate) < now) return false;
+  if (event.spotlightStartDate && new Date(event.spotlightStartDate) > now) return false;
+  return true;
+}
+
+// Purchased but the window hasn't started yet.
+export function isSpotlightScheduled(event: SpotlightFields): boolean {
+  if (!event.spotlight || !event.spotlightStartDate || !event.spotlightEndDate) return false;
+  const now = new Date();
+  return new Date(event.spotlightStartDate) > now && new Date(event.spotlightEndDate) >= now;
+}

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -156,6 +156,8 @@ export type OperationResult<T> = {
   isSuccess: boolean;
   data: T;
   errors: string[];
+  isForbidden?: boolean;
+  isNotFound?: boolean;
 };
 
 // ---- Moderation / Event Reports ----

--- a/src/types/spotlight.ts
+++ b/src/types/spotlight.ts
@@ -1,0 +1,54 @@
+// Types for the Spotlight placement purchase flow.
+// Mirrors the Backend /api/spotlight contract (all responses wrapped in OperationResult<T>).
+
+// Payment providers shown in the UI. "mock" is the auto-approving gateway used
+// while real Stripe/Klarna/Swish integrations are pending.
+export type SpotlightProvider = "stripe" | "klarna" | "swish" | "mock";
+
+// GET /api/spotlight/packages
+export type SpotlightPackage = {
+  code: string; // e.g. "spotlight_7"
+  name: string;
+  durationDays: number;
+  amount: number;
+  currency: string; // e.g. "SEK"
+};
+
+// POST /api/spotlight/checkout — request body
+export type SpotlightCheckoutRequest = {
+  eventId: string; // guid
+  packageCode: string;
+  provider: SpotlightProvider;
+};
+
+// POST /api/spotlight/checkout — response data
+export type SpotlightCheckoutResponse = {
+  paymentId: string;
+  provider: string;
+  status: string;
+  amount: number;
+  currency: string;
+  checkoutUrl: string | null;
+  providerReference: string | null;
+};
+
+// POST /api/spotlight/confirm — request body
+export type SpotlightConfirmRequest = {
+  paymentId: string;
+};
+
+// SpotlightPayment — returned by /confirm and /payments
+export type SpotlightPayment = {
+  id: string;
+  eventId: string;
+  packageCode: string;
+  durationDays: number;
+  amount: number;
+  currency: string;
+  provider: string;
+  status: string;
+  spotlightStartDate: string;
+  spotlightEndDate: string;
+  createdAt: string;
+  completedAt: string | null;
+};

--- a/src/types/spotlight.ts
+++ b/src/types/spotlight.ts
@@ -1,54 +1,15 @@
-// Types for the Spotlight placement purchase flow.
-// Mirrors the Backend /api/spotlight contract (all responses wrapped in OperationResult<T>).
+// Types for the Spotlight placement purchase flow (Stripe Checkout).
+// Mirrors the Backend POST /api/events/{eventId}/spotlight/checkout contract
+// (responses wrapped in OperationResult<T>).
 
-// Payment providers shown in the UI. "mock" is the auto-approving gateway used
-// while real Stripe/Klarna/Swish integrations are pending.
-export type SpotlightProvider = "stripe" | "klarna" | "swish" | "mock";
-
-// GET /api/spotlight/packages
-export type SpotlightPackage = {
-  code: string; // e.g. "spotlight_7"
-  name: string;
-  durationDays: number;
-  amount: number;
-  currency: string; // e.g. "SEK"
-};
-
-// POST /api/spotlight/checkout — request body
+// POST /api/events/{eventId}/spotlight/checkout — request body
 export type SpotlightCheckoutRequest = {
-  eventId: string; // guid
-  packageCode: string;
-  provider: SpotlightProvider;
+  days: number; // 1–90
+  startDate?: string; // ISO date; omitted = starts today; must not be in the past
 };
 
-// POST /api/spotlight/checkout — response data
+// POST /api/events/{eventId}/spotlight/checkout — response data
 export type SpotlightCheckoutResponse = {
-  paymentId: string;
-  provider: string;
-  status: string;
-  amount: number;
-  currency: string;
-  checkoutUrl: string | null;
-  providerReference: string | null;
-};
-
-// POST /api/spotlight/confirm — request body
-export type SpotlightConfirmRequest = {
-  paymentId: string;
-};
-
-// SpotlightPayment — returned by /confirm and /payments
-export type SpotlightPayment = {
-  id: string;
-  eventId: string;
-  packageCode: string;
-  durationDays: number;
-  amount: number;
-  currency: string;
-  provider: string;
-  status: string;
-  spotlightStartDate: string;
-  spotlightEndDate: string;
-  createdAt: string;
-  completedAt: string | null;
+  checkoutUrl: string; // Stripe-hosted checkout page — redirect the browser here
+  sessionId: string; // Stripe Checkout session id (cs_...)
 };


### PR DESCRIPTION
## Summary

Wires the organiser spotlight purchase flow to the **live** backend Stripe endpoint, replacing the mocked packages-based flow.

This branch includes two commits:
1. Cherry-pick of the mocked spotlight purchase UI from `feature/spotlight-payments-ui` (kept its dialog UX/design — that branch is now superseded and can be deleted).
2. Rewiring to the real contract: `POST /api/events/{eventId}/spotlight/checkout` with body `{ days: 1–90, startDate?: ISO date }` → redirect the browser to the returned Stripe `checkoutUrl`.

### What changed
- **`SpotlightPurchaseDialog`** (opened from the Spotlight button on each My Events card): day presets (7/14/30) + custom input (1–90), optional start-date picker (min = today, omitted = starts today), live `days × 99 kr` price, pay button disabled while loading, full-page redirect to Stripe. Removed the mock provider-picker (Stripe/Klarna/Swish) and mock `/confirm` step — Stripe Checkout owns the payment-method UI, confirmation is webhook-driven server-side.
- If the event already has an active or scheduled spotlight window, the dialog shows a yellow status banner (period dates) alongside the purchase form.
- **New public page `/spotlight/success`** — Stripe return URL (`?session_id=cs_...`), no auth guard, "spotlight activates within a minute or two" copy, CTA to My Events.
- **New public page `/spotlight/cancel`** — nothing charged, retry CTA.
- **`src/lib/spotlight.ts`** — single source for the daily price, day limits and `isSpotlightActive`/`isSpotlightScheduled` helpers. `StepSpotlight` and My Events now import from it.
- Errors: `OperationResult.errors[]` surfaced in the dialog; dedicated Swedish messages for 403 (not owner) and 404 (event not found/inactive). 401 is handled by the existing axios refresh-then-login interceptor.
- Runtime copy is Swedish (matches the app post-#87); the EN string archive `strings-en.ts` was updated to match the new flow.

### Important notes
- **Price placeholder:** 99 SEK/day lives in ONE place (`src/lib/spotlight.ts`, `SPOTLIGHT_PRICE_PER_DAY_SEK`) and is display-only — the authoritative price is in the backend Stripe session. Pending product-owner confirmation.
- **Do not rename** `/spotlight/success` and `/spotlight/cancel` — these URLs are baked into backend config as Stripe redirect URLs.
- Follow-up (out of scope): `StepSpotlight` in the create/edit form still writes `spotlight`/`spotlightStartDate`/`spotlightEndDate` directly via event create/update — the backend should ignore/guard those now that spotlight is paid.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — 24 routes incl. `/spotlight/success` + `/spotlight/cancel` (both static)
- [ ] Manual: buy spotlight on an owned event → Stripe test checkout → redirected to `/spotlight/success` → spotlight badge appears after webhook
- [ ] Manual: cancel on the Stripe page → `/spotlight/cancel`
- [ ] Manual: 403 path (event owned by another organiser) shows the owner error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
