### PR TITLE
fix: Alltid öppet could not be saved — stale schedule fields leaked into payload

### DIFF
--- a/src/lib/validation/create-event-schema.ts
+++ b/src/lib/validation/create-event-schema.ts
@@ -175,10 +175,13 @@ export const createPayload = (data: CreateEventFormData): CreateEventDto => {
     singleDates: data.hasMultipleDates ? singleDatePayload : undefined,
 
     hasSchedule: data.hasSchedule,
-    weekdays: weekdayIndices.length > 0 ? weekdayIndices : undefined,
+    // Only send schedule fields when the recurring mode is selected — stale
+    // values from a previously chosen mode would fail backend validation
+    // (HasSchedule must be true whenever ScheduleStartTime is set).
+    weekdays: data.hasSchedule && weekdayIndices.length > 0 ? weekdayIndices : undefined,
 
-    scheduleStartTime: data.scheduleStartTime || undefined,
-    scheduleEndTime: data.scheduleEndTime || undefined,
+    scheduleStartTime: data.hasSchedule ? data.scheduleStartTime || undefined : undefined,
+    scheduleEndTime: data.hasSchedule ? data.scheduleEndTime || undefined : undefined,
 
     isAlwaysOpen: data.isAlwaysOpen,
     // spotlight / spotlightStartDate / spotlightEndDate are intentionally


### PR DESCRIPTION
## Bug
Picking **Alltid öppet** (or switching between timing modes at all) in the event form failed to save whenever schedule values had ever been set — including every edit of an event that previously had a recurring schedule.

## Root cause
`createPayload` sent `scheduleStartTime`/`scheduleEndTime`/`weekdays` unconditionally from form state. Switching mode does not clear the old mode's values, and the backend validator (correctly) rejects `ScheduleStartTime` when `HasSchedule` is false → 400 → "Uppdateringen misslyckades".

## Fix
Gate the schedule fields on `hasSchedule` in `createPayload` — mirrors how single-date fields (`startDate`/`endDate`) and `singleDates` were already gated on their mode flags.

## Test
- `npx tsc --noEmit` clean
- Payload for always-open after touching recurring fields now contains only `isAlwaysOpen: true` + mode flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)