### PR TITLE
feat: show spotlight price with VAT (exkl./inkl. moms)

### DIFF
--- a/src/components/spotlight/SpotlightPurchaseDialog.tsx
+++ b/src/components/spotlight/SpotlightPurchaseDialog.tsx
@@ -17,9 +17,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
-import { useSpotlightCheckout } from "@/hooks/useSpotlight";
+import { useSpotlightCheckout, useSpotlightPricing } from "@/hooks/useSpotlight";
 import {
   SPOTLIGHT_PRICE_PER_DAY_SEK,
+  SPOTLIGHT_VAT_RATE_PERCENT,
   SPOTLIGHT_MIN_DAYS,
   SPOTLIGHT_MAX_DAYS,
   formatSek,
@@ -52,6 +53,14 @@ export function SpotlightPurchaseDialog({ open, onOpenChange, event }: Props) {
   const [errorMessage, setErrorMessage] = React.useState<string>("");
 
   const checkout = useSpotlightCheckout();
+  const { data: pricing } = useSpotlightPricing();
+
+  // Prefer the authoritative backend price; fall back to constants while the
+  // pricing request is loading or if it fails. Net is ex-VAT; gross (net + MOMS)
+  // is what Stripe actually charges, so every total shown to the user is gross.
+  const netPerDay = pricing?.dailyPriceNet ?? SPOTLIGHT_PRICE_PER_DAY_SEK;
+  const vatRate = pricing?.vatRatePercent ?? SPOTLIGHT_VAT_RATE_PERCENT;
+  const grossPerDay = pricing?.dailyPriceGross ?? netPerDay * (1 + vatRate / 100);
 
   const today = React.useMemo(() => {
     const d = new Date();
@@ -88,7 +97,9 @@ export function SpotlightPurchaseDialog({ open, onOpenChange, event }: Props) {
 
   const daysValid =
     Number.isInteger(days) && days >= SPOTLIGHT_MIN_DAYS && days <= SPOTLIGHT_MAX_DAYS;
-  const total = daysValid ? days * SPOTLIGHT_PRICE_PER_DAY_SEK : 0;
+  const netTotal = daysValid ? days * netPerDay : 0;
+  const grossTotal = daysValid ? days * grossPerDay : 0;
+  const vatTotal = grossTotal - netTotal;
 
   const handleDaysInput = (raw: string) => {
     setDaysInput(raw);
@@ -208,7 +219,7 @@ export function SpotlightPurchaseDialog({ open, onOpenChange, event }: Props) {
                   >
                     <span className="text-base font-semibold">{d} dagar</span>
                     <span className="text-xs text-muted-foreground">
-                      {formatSek(d * SPOTLIGHT_PRICE_PER_DAY_SEK)}
+                      {formatSek(d * grossPerDay, { decimals: 2 })}
                     </span>
                   </button>
                 );
@@ -280,23 +291,34 @@ export function SpotlightPurchaseDialog({ open, onOpenChange, event }: Props) {
               </div>
             </div>
 
-            {/* Price summary */}
-            <div className="rounded-xl border bg-muted/30 p-3 text-sm">
+            {/* Price summary — net, VAT and gross so the amount matches Stripe. */}
+            <div className="space-y-1 rounded-xl border bg-muted/30 p-3 text-sm">
               <div className="flex justify-between">
                 <span>
-                  {daysValid ? days : "–"} dagar × {formatSek(SPOTLIGHT_PRICE_PER_DAY_SEK)}
+                  {daysValid ? days : "–"} dagar × {formatSek(netPerDay)} exkl. moms
                 </span>
-                <span className="font-semibold">{daysValid ? formatSek(total) : "–"}</span>
+                <span>{daysValid ? formatSek(netTotal) : "–"}</span>
+              </div>
+              <div className="flex justify-between text-muted-foreground">
+                <span>Moms ({vatRate} %)</span>
+                <span>{daysValid ? formatSek(vatTotal, { decimals: 2 }) : "–"}</span>
+              </div>
+              <div className="flex justify-between border-t pt-1 font-semibold">
+                <span>Att betala inkl. moms</span>
+                <span>{daysValid ? formatSek(grossTotal, { decimals: 2 }) : "–"}</span>
               </div>
               <p className="mt-1 text-xs text-muted-foreground">
-                Priset är {formatSek(SPOTLIGHT_PRICE_PER_DAY_SEK)} per dag. Du skickas till Stripe
-                för säker betalning.
+                Priset är {formatSek(netPerDay)} per dag exkl. moms (
+                {formatSek(grossPerDay, { decimals: 2 })} inkl. moms). Du skickas till Stripe för
+                säker betalning.
               </p>
             </div>
 
             <Button className="w-full" disabled={!daysValid || isBusy} onClick={handlePurchase}>
               {isBusy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {isBusy ? "Startar betalning…" : `Betala ${daysValid ? formatSek(total) : ""}`}
+              {isBusy
+                ? "Startar betalning…"
+                : `Betala ${daysValid ? formatSek(grossTotal, { decimals: 2 }) : ""}`}
             </Button>
           </div>
         )}

--- a/src/hooks/useSpotlight.ts
+++ b/src/hooks/useSpotlight.ts
@@ -1,7 +1,25 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/axios";
 import { OperationResult } from "@/types/events";
-import { SpotlightCheckoutRequest, SpotlightCheckoutResponse } from "@/types/spotlight";
+import {
+  SpotlightCheckoutRequest,
+  SpotlightCheckoutResponse,
+  SpotlightPricing,
+} from "@/types/spotlight";
+
+// GET /api/spotlight/pricing — per-day price + VAT breakdown (anonymous).
+// Pricing changes rarely, so cache it aggressively. Components fall back to
+// the SPOTLIGHT_* constants in lib/spotlight while this is loading.
+export function useSpotlightPricing() {
+  return useQuery({
+    queryKey: ["spotlight-pricing"],
+    queryFn: async () => {
+      const response = await api.get<OperationResult<SpotlightPricing>>("/spotlight/pricing");
+      return response.data.data;
+    },
+    staleTime: 1000 * 60 * 60, // 1h
+  });
+}
 
 // POST /api/events/{eventId}/spotlight/checkout — start a Stripe Checkout
 // session for the event (owner only). On success redirect the browser to

--- a/src/lib/spotlight.ts
+++ b/src/lib/spotlight.ts
@@ -3,22 +3,27 @@
 
 import type { EventDto } from "@/types/events";
 
-// PLACEHOLDER PRICE: 99 SEK/day is pending product-owner confirmation.
-// The authoritative price lives in the backend Stripe checkout — this constant
-// is display-only and must be kept in sync with it.
+// FALLBACK PRICE: 99 SEK/day (ex-VAT). The authoritative price + VAT now come
+// from the backend (GET /api/spotlight/pricing via useSpotlightPricing); these
+// constants are only used while that request is loading or if it fails.
 export const SPOTLIGHT_PRICE_PER_DAY_SEK = 99;
+export const SPOTLIGHT_VAT_RATE_PERCENT = 25;
 
 // Allowed purchase duration (mirrors backend validation: days 1–90).
 export const SPOTLIGHT_MIN_DAYS = 1;
 export const SPOTLIGHT_MAX_DAYS = 90;
 
-// Formats whole-SEK amounts, e.g. "693 kr".
-export const formatSek = (amount: number) =>
-  new Intl.NumberFormat("sv-SE", {
+// Formats SEK amounts. Defaults to whole SEK ("693 kr"); pass { decimals: 2 }
+// for VAT/gross figures that aren't round ("123,75 kr").
+export const formatSek = (amount: number, opts?: { decimals?: number }) => {
+  const decimals = opts?.decimals ?? 0;
+  return new Intl.NumberFormat("sv-SE", {
     style: "currency",
     currency: "SEK",
-    maximumFractionDigits: 0,
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
   }).format(amount);
+};
 
 type SpotlightFields = Pick<EventDto, "spotlight" | "spotlightStartDate" | "spotlightEndDate">;
 

--- a/src/types/spotlight.ts
+++ b/src/types/spotlight.ts
@@ -13,3 +13,13 @@ export type SpotlightCheckoutResponse = {
   checkoutUrl: string; // Stripe-hosted checkout page — redirect the browser here
   sessionId: string; // Stripe Checkout session id (cs_...)
 };
+
+// GET /api/spotlight/pricing — per-day price with VAT breakdown.
+// dailyPriceGross is what Stripe actually charges (net + Swedish MOMS).
+export type SpotlightPricing = {
+  currency: string; // e.g. "sek"
+  dailyPriceNet: number; // 99.00 — excl. VAT
+  vatRatePercent: number; // 25
+  dailyVatAmount: number; // 24.75
+  dailyPriceGross: number; // 123.75 — incl. VAT
+};


### PR DESCRIPTION
## Why

The spotlight purchase dialog hardcoded a bare **"99 kr"** net price. Stripe adds 25% MOMS on top, so organisers saw *99* but were charged *123,75* — confusing and the reason a support report came in. This shows the VAT clearly and reads the real price from the backend so the two never drift.

## What

- New **`useSpotlightPricing()`** hook → `GET /api/spotlight/pricing` (backend PR: Go-Do-AB/Backend#234), returning net / VAT rate / VAT amount / gross per day.
- Dialog now shows a **net → moms → gross breakdown**, and **every total the organiser sees** (preset chips, summary, "Betala" button) is the **gross** amount Stripe actually charges:
  - `7 dagar × 99 kr exkl. moms` = 693 kr
  - `Moms (25 %)` = 173,25 kr
  - **Att betala inkl. moms** = 866,25 kr
- Per-day caption: *"Priset är 99 kr per dag exkl. moms (123,75 kr inkl. moms)."*
- Falls back to the `SPOTLIGHT_*` constants (99 kr / 25 %) while the request loads or if it fails.
- `formatSek` gained an optional `{ decimals: 2 }` for the non-round VAT/gross figures.

## Verify

- `eslint` clean, `tsc --noEmit` clean.
- Depends on backend #234 being deployed for live data; the fallback keeps the UI correct meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)